### PR TITLE
fix: align sequential move semantics for jsonPatchToCrdt

### DIFF
--- a/.changeset/twenty-socks-ring.md
+++ b/.changeset/twenty-socks-ring.md
@@ -1,0 +1,9 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Fix `move` edge cases so sequential internals align with RFC 6902 and `applyPatch`.
+
+- Apply sequential `move` as remove-then-add in `jsonPatchToCrdt`, while capturing the source value before removal.
+- Treat self-move (`from === path`) as a no-op in sequential compilation and low-level application flow.
+- Add regression tests for forward array moves, self-move behavior, and parity between `jsonPatchToCrdt` and `applyPatch`.


### PR DESCRIPTION
## Summary
Fixes divergence between `jsonPatchToCrdt` and `applyPatch` for sequential `move` edge cases.

Closes #3.

## What changed
- Apply sequential `move` in `jsonPatchToCrdt` as remove-then-add with the source value captured before removal.
- Treat self-move (`from === path`) as a no-op in sequential compile/apply flow.
- Update sequential move compilation ordering to reflect RFC semantics for array forward moves.
- Add regression tests for:
  - forward array move (`/list/0 -> /list/2`)
  - self-move (`/a -> /a`)
  - parity between `jsonPatchToCrdt` and `applyPatch`
- Add a patch changeset for release notes.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`