### PR TITLE
fix: enforce strict JSON Pointer escapes and array index tokens

### DIFF
--- a/.changeset/cyan-horses-grin.md
+++ b/.changeset/cyan-horses-grin.md
@@ -1,0 +1,10 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Harden JSON Pointer and array-index parsing to match strict RFC behavior.
+
+- Reject invalid pointer escape sequences (anything other than `~0` and `~1`).
+- Reject leading-zero array indices (for example `/arr/01`) when resolving array paths.
+- Keep numeric-looking object keys valid when parent values are objects (for example `/obj/01`).
+- Add regression tests for invalid escapes, strict array-index parsing, and object-key compatibility.


### PR DESCRIPTION
## Summary
This PR fixes Issue #5 by tightening JSON Pointer and array index parsing to match strict RFC 6901/6902 expectations.

## Changes
- Enforced strict JSON Pointer unescaping in `parseJsonPointer`.
  - Only `~0` and `~1` are accepted.
  - Invalid sequences like `~2` and trailing `~` now throw.
- Enforced strict array index token grammar for array addressing.
  - Accepted form is `0|[1-9][0-9]*`.
  - Leading-zero indices like `/arr/01` are rejected with `INVALID_POINTER`.
- Applied strict index-token validation in `getAtJson` as well, so lookup/compile paths are consistent.
- Kept backward compatibility for numeric-looking object keys when parent is an object (e.g. `/obj/01`).
- Added a patch changeset entry.

## Tests
Added regression coverage for:
- rejecting invalid pointer escapes (`/a~2b`, `/a~`),
- rejecting leading-zero array indices for arrays (`/arr/01`),
- allowing numeric-looking object keys with leading zeros (`/obj/01`).

## Validation
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #5
