### PR TITLE
fix: guard forkState against unsafe actor reuse

### DIFF
--- a/.changeset/odd-meals-jam.md
+++ b/.changeset/odd-meals-jam.md
@@ -1,0 +1,9 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Harden `forkState` against unsafe same-actor replica forking.
+
+- Reject `forkState(origin, actor)` by default when `actor` matches `origin.clock.actor`.
+- Add an explicit `allowActorReuse` opt-in for advanced workflows that intentionally reuse actor IDs.
+- Document actor uniqueness requirements and add regression tests for default rejection and explicit override behavior.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export type {
   ApplyPatchOptions,
   CrdtState,
   DiffOptions,
+  ForkStateOptions,
   JsonPatch,
   JsonPatchOp,
   JsonPrimitive,

--- a/src/state.ts
+++ b/src/state.ts
@@ -18,6 +18,7 @@ import type {
   ApplyResult,
   CrdtState,
   Doc,
+  ForkStateOptions,
   IntentOp,
   JsonPatchOp,
   JsonValue,
@@ -77,8 +78,17 @@ export function createState(
 /**
  * Fork a replica from a shared origin state while assigning a new local actor ID.
  * The forked state has an independent document clone and clock.
+ * By default this rejects actor reuse to prevent duplicate-dot collisions across peers.
  */
-export function forkState(origin: CrdtState, actor: ActorId): CrdtState {
+export function forkState(
+  origin: CrdtState,
+  actor: ActorId,
+  options: ForkStateOptions = {},
+): CrdtState {
+  if (actor === origin.clock.actor && !options.allowActorReuse) {
+    throw new Error(`forkState actor must be unique; refusing to reuse origin actor '${actor}'`);
+  }
+
   return {
     doc: cloneDoc(origin.doc),
     clock: createClock(actor, origin.clock.ctr),

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,15 @@ export type Doc = { root: Node };
 /** Combined CRDT state: a document and its associated clock. */
 export type CrdtState = { doc: Doc; clock: Clock };
 
+/** Options for `forkState`. */
+export interface ForkStateOptions {
+  /**
+   * Allow reusing the origin actor ID when forking.
+   * Defaults to `false` to prevent duplicate-dot collisions across replicas.
+   */
+  allowActorReuse?: boolean;
+}
+
 /** Result from applying a patch for a specific actor using a shared version vector. */
 export type ApplyPatchAsActorResult = {
   /** Updated CRDT state for the actor that produced this patch. */

--- a/tests/crdt.test.ts
+++ b/tests/crdt.test.ts
@@ -642,6 +642,21 @@ describe("clock and state", () => {
     expect(list).toContain("fromB");
   });
 
+  it("rejects same-actor fork reuse by default", () => {
+    const origin = createState({ count: 0 }, { actor: "A" });
+    expect(() => forkState(origin, "A")).toThrow(
+      "forkState actor must be unique; refusing to reuse origin actor 'A'",
+    );
+  });
+
+  it("allows same-actor fork reuse only when explicitly enabled", () => {
+    const origin = createState({ count: 0 }, { actor: "A" });
+    const reused = forkState(origin, "A", { allowActorReuse: true });
+    expect(toJson(reused)).toEqual({ count: 0 });
+    expect(reused.clock.actor).toBe("A");
+    expect(reused.clock.ctr).toBe(origin.clock.ctr);
+  });
+
   it("applies patches with the friendly API", () => {
     const state = createState({ list: ["a"] }, { actor: "A" });
     const next = applyPatch(state, [{ op: "add", path: "/list/-", value: "b" }]);


### PR DESCRIPTION
## Summary
- reject `forkState(origin, actor)` by default when `actor` matches `origin.clock.actor`
- add explicit opt-in via `forkState(origin, actor, { allowActorReuse: true })` for advanced same-actor workflows
- export `ForkStateOptions` and document actor-uniqueness requirements in the README
- add regression tests for default rejection and explicit opt-in behavior
- add a changeset entry for release notes

## Problem
Issue #6 identified that same-actor forks can mint duplicate dots from the same counter lineage, causing order-dependent merges and potential lost updates.

## Fix Details
- `forkState` now throws when attempting same-actor reuse unless explicitly allowed
- this makes safe behavior the default and keeps unsafe behavior as explicit opt-in
- docs now clarify why actor IDs must remain unique per live peer

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #6
