### PR TITLE
fix: enforce shared RGA metadata checks during merge

### DIFF
--- a/.changeset/six-goats-think.md
+++ b/.changeset/six-goats-think.md
@@ -1,0 +1,7 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Enforce consistency checks when merging shared RGA element IDs.
+
+When both replicas contain the same element ID, merge now verifies that `prev` and `insDot` metadata are identical. Conflicts return typed `LINEAGE_MISMATCH` errors with path context instead of silently merging inconsistent sequence topology.


### PR DESCRIPTION
## Summary
Closes #16 by enforcing consistency checks for shared RGA element IDs during merge.

## What changed
- Added explicit validation in `mergeSeq` (`src/merge.ts`) when the same element ID exists on both sides:
  - `prev` must match
  - `insDot` must match
- On mismatch, merge now fails deterministically with a typed `LINEAGE_MISMATCH` error (via `tryMergeDoc` / `tryMergeState`) including path context.
- Added regression tests in `tests/crdt.test.ts` for:
  - conflicting `prev` metadata on shared IDs
  - conflicting `insDot` metadata on shared IDs
- Added a changeset for release notes/versioning.

## Why
The previous merge logic assumed shared IDs had consistent metadata but didn’t enforce it. Corrupted or foreign input could silently produce inconsistent sequence topology.

## Testing
- `bun fmt`
- `bun lint`
- `bun lint:fix`
- `bun typecheck`
- `bun run test`

Closes #16
