### PR TITLE
fix: use typed lookup errors for patch reason mapping (closes #17)

### DIFF
--- a/.changeset/fuzzy-rivers-pretend.md
+++ b/.changeset/fuzzy-rivers-pretend.md
@@ -1,0 +1,9 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Replace brittle lookup-error string matching with structured `JsonLookupError` types in patch path resolution.
+
+Map typed lookup failure codes to patch failure reasons in `mapLookupErrorToPatchReason` to preserve error semantics without relying on message text.
+
+Add targeted regression tests for invalid array-index tokens and non-container traversal to assert exact failure reason mapping.

--- a/tests/crdt.test.ts
+++ b/tests/crdt.test.ts
@@ -969,6 +969,30 @@ describe("clock and state", () => {
     }
   });
 
+  it("maps lookup invalid array index tokens to INVALID_POINTER", () => {
+    const state = createState({ list: [1] }, { actor: "A" });
+    const result = tryApplyPatch(state, [{ op: "copy", from: "/list/x", path: "/c" }]);
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("INVALID_POINTER");
+      expect(result.error.path).toBe("/list/x");
+      expect(result.error.opIndex).toBe(0);
+    }
+  });
+
+  it("maps lookup non-container traversal to INVALID_TARGET", () => {
+    const state = createState({ num: 1 }, { actor: "A" });
+    const result = tryApplyPatch(state, [{ op: "copy", from: "/num/x", path: "/c" }]);
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("INVALID_TARGET");
+      expect(result.error.path).toBe("/num/x");
+      expect(result.error.opIndex).toBe(0);
+    }
+  });
+
   it("throws PatchError with typed metadata when move source is missing", () => {
     const state = createState({ a: 1 }, { actor: "A" });
 


### PR DESCRIPTION
## Summary
This PR resolves #17 by replacing brittle lookup-error string matching with typed lookup errors and preserving existing patch failure semantics.

## Changes
- Added JsonLookupErrorCode and JsonLookupError in src/patch.ts for lookup failures raised by getAtJson.
- Updated getAtJson to throw structured lookup errors for:
  - expected array index token errors
  - out-of-bounds array index errors
  - missing object key errors
  - non-container traversal errors
- Replaced message.includes(...) matching in mapLookupErrorToPatchReason with typed code mapping via JsonLookupError.
- Added regression tests in tests/crdt.test.ts to assert exact mappings for:
  - invalid array index token -> INVALID_POINTER
  - non-container traversal -> INVALID_TARGET
- Added changeset: .changeset/fuzzy-rivers-pretend.md.

## Why
String-based error mapping is fragile and can break on message wording changes. Typed lookup errors make the mapping explicit and stable while keeping behavior unchanged.

## Validation
- bun lint:fix
- bun fmt
- bun typecheck
- bun run test

All checks passed.

Closes #17
