### PR TITLE
fix: add scalability guardrail for LCS array diff (closes #19)

### DIFF
--- a/.changeset/wise-cats-cheer.md
+++ b/.changeset/wise-cats-cheer.md
@@ -1,0 +1,9 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Add scalability guardrails for LCS array diffing by introducing `lcsMaxCells` in `DiffOptions`.
+
+When array diffing uses the LCS strategy, automatically fall back to atomic replacement if the LCS matrix would exceed the configured cell cap (default `250_000`).
+
+Document array diff complexity tradeoffs in the README and add regression coverage for default fallback and configurable guardrail behavior.

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,7 +278,21 @@ export type JsonPatchToCrdtOptions = {
 };
 
 /** Options for `crdtToJsonPatch` and `diffJsonPatch`. */
-export type DiffOptions = { arrayStrategy?: "atomic" | "lcs" };
+export type DiffOptions = {
+  /**
+   * Array diff mode.
+   * - `"lcs"` (default): index-level edits using LCS.
+   * - `"atomic"`: one-op root/field replacement for changed arrays.
+   */
+  arrayStrategy?: "atomic" | "lcs";
+  /**
+   * Maximum LCS matrix cells (`(base.length + 1) * (next.length + 1)`) before
+   * falling back to atomic replacement. Defaults to `250_000`.
+   *
+   * Set to `Number.POSITIVE_INFINITY` to always allow LCS.
+   */
+  lcsMaxCells?: number;
+};
 
 /**
  * Internal sentinel key used in `IntentOp` to represent root-level operations.


### PR DESCRIPTION
## Summary
This PR resolves #19 by adding scalability guardrails for LCS array diffing in `diffJsonPatch`.

## Problem
`diffArray` previously allocated an `O(n*m)` LCS matrix without any size cap, which could cause high memory and CPU costs for large arrays.

## Changes
- Added configurable LCS matrix guardrail in `src/patch.ts`:
  - new default cap: `250_000` cells
  - if `(base.length + 1) * (next.length + 1)` exceeds the cap, array diff falls back to atomic `replace`
- Added `lcsMaxCells?: number` to `DiffOptions` in `src/types.ts`:
  - lower values force earlier atomic fallback
  - `Number.POSITIVE_INFINITY` allows unbounded LCS behavior
- Kept `arrayStrategy` semantics intact:
  - `"atomic"` remains always-atomic
  - `"lcs"` now guarded by `lcsMaxCells`
- Added regression coverage in `tests/crdt.test.ts`:
  - large-array default fallback to atomic replace
  - override with higher `lcsMaxCells` keeps LCS behavior
  - low `lcsMaxCells` forces atomic fallback even on small arrays
- Documented complexity tradeoffs and guardrail behavior in `README.md`.
- Added required changeset: `.changeset/wise-cats-cheer.md`.

## Validation
- `bun lint:fix`
- `bun fmt`
- `bun typecheck`
- `bun run test`

All checks passed.

Closes #19
