### PR TITLE
feat: add tombstone compaction APIs for long-lived documents (closes #20)

### DIFF
--- a/.changeset/curvy-birds-applaud.md
+++ b/.changeset/curvy-birds-applaud.md
@@ -1,0 +1,9 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Add tombstone compaction APIs for long-lived documents and states via `compactDocTombstones` (internals) and `compactStateTombstones` (public API).
+
+Prune causally-stable object tombstones and sequence tombstones that no longer anchor any live descendants, with optional in-place mutation support for server-side maintenance workflows.
+
+Document compaction safety conditions and add regression coverage to verify correctness and unchanged materialized semantics before/after compaction.

--- a/src/compact.ts
+++ b/src/compact.ts
@@ -1,0 +1,112 @@
+import type {
+  CompactDocTombstonesResult,
+  CompactStateTombstonesResult,
+  CrdtState,
+  Doc,
+  Dot,
+  Node,
+  TombstoneCompactionOptions,
+  VersionVector,
+} from "./types";
+
+import { cloneClock } from "./clock";
+import { assertTraversalDepth } from "./depth";
+import { cloneDoc } from "./doc";
+import { objCompactTombstones } from "./nodes";
+import { rgaCompactTombstones } from "./rga";
+
+function isDotStable(stable: VersionVector, dot: Dot): boolean {
+  return (stable[dot.actor] ?? 0) >= dot.ctr;
+}
+
+/**
+ * Compact causally-stable tombstones in a document.
+ *
+ * Safety note:
+ * - Only compact at checkpoints that are causally stable across all peers you
+ *   may still merge with.
+ * - Do not merge this compacted document with replicas that might be behind
+ *   the provided checkpoint.
+ */
+export function compactDocTombstones(
+  doc: Doc,
+  options: TombstoneCompactionOptions,
+): CompactDocTombstonesResult {
+  const targetDoc = options.mutate ? doc : cloneDoc(doc);
+  const stats = {
+    objectTombstonesRemoved: 0,
+    sequenceTombstonesRemoved: 0,
+  };
+  const stable = options.stable;
+  const stack: Array<{ node: Node; depth: number }> = [{ node: targetDoc.root, depth: 0 }];
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    assertTraversalDepth(frame.depth);
+
+    if (frame.node.kind === "obj") {
+      stats.objectTombstonesRemoved += objCompactTombstones(frame.node, (dot) =>
+        isDotStable(stable, dot),
+      );
+
+      for (const entry of frame.node.entries.values()) {
+        stack.push({ node: entry.node, depth: frame.depth + 1 });
+      }
+      continue;
+    }
+
+    if (frame.node.kind === "seq") {
+      stats.sequenceTombstonesRemoved += rgaCompactTombstones(frame.node, (dot) =>
+        isDotStable(stable, dot),
+      );
+
+      for (const elem of frame.node.elems.values()) {
+        stack.push({ node: elem.value, depth: frame.depth + 1 });
+      }
+    }
+  }
+
+  return {
+    doc: targetDoc,
+    stats,
+  };
+}
+
+/**
+ * Compact causally-stable tombstones in a state document.
+ *
+ * Safety note:
+ * - Only compact at checkpoints that are causally stable across all peers you
+ *   may still merge with.
+ * - Do not merge this compacted state with replicas that might be behind the
+ *   provided checkpoint.
+ */
+export function compactStateTombstones(
+  state: CrdtState,
+  options: TombstoneCompactionOptions,
+): CompactStateTombstonesResult {
+  if (options.mutate) {
+    const docResult = compactDocTombstones(state.doc, {
+      stable: options.stable,
+      mutate: true,
+    });
+    return {
+      state,
+      stats: docResult.stats,
+    };
+  }
+
+  const nextState = {
+    doc: cloneDoc(state.doc),
+    clock: cloneClock(state.clock),
+  };
+  const docResult = compactDocTombstones(nextState.doc, {
+    stable: options.stable,
+    mutate: true,
+  });
+
+  return {
+    state: nextState,
+    stats: docResult.stats,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type {
   ApplyPatchInPlaceOptions,
   ApplyPatchOptions,
   CrdtState,
+  CompactStateTombstonesResult,
   DiffOptions,
   DeserializeErrorReason,
   ForkStateOptions,
@@ -18,6 +19,8 @@ export type {
   PatchErrorReason,
   PatchSemantics,
   SerializedState,
+  TombstoneCompactionOptions,
+  TombstoneCompactionStats,
   TryApplyPatchInPlaceResult,
   TryApplyPatchResult,
   TryMergeStateResult,
@@ -45,6 +48,9 @@ export { DeserializeError, serializeState, deserializeState } from "./serialize"
 
 // Merge
 export { MergeError, mergeState, tryMergeState } from "./merge";
+
+// Tombstone compaction
+export { compactStateTombstones } from "./compact";
 
 // Traversal limits
 export { MAX_TRAVERSAL_DEPTH, TraversalDepthError } from "./depth";

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -36,6 +36,9 @@ export {
 // Node-level materialization helper.
 export { materialize } from "./materialize";
 
+// Tombstone compaction helpers.
+export { compactDocTombstones, compactStateTombstones } from "./compact";
+
 // Low-level document merge helpers.
 export { mergeDoc, tryMergeDoc } from "./merge";
 
@@ -48,6 +51,8 @@ export type {
   ApplyPatchAsActorOptions,
   ApplyResult,
   Clock,
+  CompactDocTombstonesResult,
+  CompactStateTombstonesResult,
   CompilePatchOptions,
   Doc,
   Dot,
@@ -65,6 +70,8 @@ export type {
   SerializedDoc,
   SerializedNode,
   SerializedRgaElem,
+  TombstoneCompactionOptions,
+  TombstoneCompactionStats,
   TryMergeDocResult,
   VersionVector,
 } from "./types";
@@ -76,13 +83,14 @@ export { ROOT_KEY } from "./types";
 export { compareDot, vvHasDot, vvMerge, dotToElemId } from "./dot";
 
 // Low-level node constructors and operations.
-export { newObj, newSeq, newReg, lwwSet, objSet, objRemove } from "./nodes";
+export { newObj, newSeq, newReg, lwwSet, objSet, objRemove, objCompactTombstones } from "./nodes";
 
 // Low-level RGA operations.
 export {
   HEAD,
   rgaInsertAfter,
   rgaDelete,
+  rgaCompactTombstones,
   rgaLinearizeIds,
   rgaPrevForInsertAtIndex,
   rgaIdAtIndex,

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -45,3 +45,22 @@ export function objRemove(obj: ObjNode, key: string, dot: Dot): void {
   // You can keep entry for history or drop it; dropping is fine with remove-wins.
   obj.entries.delete(key);
 }
+
+/**
+ * Prune object tombstones that satisfy a caller-provided stability predicate.
+ * Returns the number of removed tombstone records.
+ */
+export function objCompactTombstones(obj: ObjNode, isStable: (dot: Dot) => boolean): number {
+  let removed = 0;
+
+  for (const [key, dot] of obj.tombstone.entries()) {
+    if (!isStable(dot)) {
+      continue;
+    }
+
+    obj.tombstone.delete(key);
+    removed += 1;
+  }
+
+  return removed;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,38 @@ export type TryMergeDocResult = { ok: true; doc: Doc } | { ok: false; error: App
 /** Non-throwing result for `mergeState`. */
 export type TryMergeStateResult = { ok: true; state: CrdtState } | { ok: false; error: ApplyError };
 
+/** Options for tombstone compaction helpers. */
+export type TombstoneCompactionOptions = {
+  /**
+   * Causally stable checkpoint. Only tombstones at or below this checkpoint
+   * are candidates for pruning.
+   */
+  stable: VersionVector;
+  /**
+   * Mutate the input value in place.
+   * Defaults to `false` (immutable output).
+   */
+  mutate?: boolean;
+};
+
+/** Counts emitted by tombstone compaction helpers. */
+export type TombstoneCompactionStats = {
+  objectTombstonesRemoved: number;
+  sequenceTombstonesRemoved: number;
+};
+
+/** Result for `compactDocTombstones`. */
+export type CompactDocTombstonesResult = {
+  doc: Doc;
+  stats: TombstoneCompactionStats;
+};
+
+/** Result for `compactStateTombstones`. */
+export type CompactStateTombstonesResult = {
+  state: CrdtState;
+  stats: TombstoneCompactionStats;
+};
+
 /** Options-object overload shape for low-level JSON Patch -> CRDT conversion. */
 export type JsonPatchToCrdtOptions = {
   base: Doc;


### PR DESCRIPTION
## Summary
This PR resolves #20 by introducing tombstone compaction APIs for long-lived documents, driven by causal-stability checkpoints.

## Problem
Object tombstones and sequence tombstones can accumulate over time, increasing memory usage and slowing operations in long-lived replicas.

## Changes
### New compaction APIs
- Public API:
  - `compactStateTombstones(state, options)`
- Internals API:
  - `compactDocTombstones(doc, options)`

Both APIs accept:
- `stable: VersionVector` (causal-stability checkpoint)
- `mutate?: boolean` (default immutable, optional in-place compaction)

### Compaction behavior
- Object tombstones (`ObjNode.tombstone`):
  - prune tombstones whose delete dot is causally stable at the provided checkpoint.
- Sequence tombstones (`RgaSeq`):
  - prune tombstoned elements only when causally stable **and** they do not anchor any live descendants.
  - this preserves traversal/materialization semantics and avoids reordering live sequence content.

### New low-level helpers
- `objCompactTombstones` in `src/nodes.ts`
- `rgaCompactTombstones` in `src/rga.ts`

### Exports and types
- Added compaction types:
  - `TombstoneCompactionOptions`
  - `TombstoneCompactionStats`
  - `CompactDocTombstonesResult`
  - `CompactStateTombstonesResult`
- Wired exports through `src/index.ts` and `src/internals.ts`.

### Documentation
- Added README section for tombstone compaction:
  - safety conditions for pruning
  - public and internals usage examples
  - server-side maintenance workflow guidance

### Tests
Added regression coverage for:
- stable object tombstone compaction
- unstable object tombstone preservation
- stable sequence tombstone compaction when no live descendants depend on tombstones
- preservation of tombstoned sequence anchors when live descendants still depend on them
- in-place document compaction workflow

Also verifies materialized semantics remain unchanged after compaction.

### Changeset
- Added `.changeset/curvy-birds-applaud.md`

## Validation
- `bun lint:fix`
- `bun fmt`
- `bun typecheck`
- `bun run test`

All checks passed.

Closes #20
