### PR TITLE
chore: declare runtime/tooling requirements in package metadata (closes #21)

### DIFF
--- a/.changeset/fancy-candles-end.md
+++ b/.changeset/fancy-candles-end.md
@@ -1,0 +1,7 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Declare runtime/tooling requirements in `package.json` by adding `engines.node` (`>=18`) and `packageManager` (`bun@1.3.7`).
+
+Align README runtime requirements wording with package metadata for contributor tooling consistency.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install json-patch-to-crdt
 
 - Node.js `>= 18` (for package consumers).
 - TypeScript `^5` when type-checking in your project.
-- Bun is optional (used for this repo's own build/test scripts).
+- Bun `1.3.7` is used for this repo's own build/test scripts.
 
 ## Quick Start (Recommended API)
 

--- a/package.json
+++ b/package.json
@@ -55,5 +55,9 @@
   },
   "peerDependencies": {
     "typescript": "^5"
-  }
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "bun@1.3.7"
 }


### PR DESCRIPTION
## Summary
This PR resolves #21 by declaring runtime/tooling requirements in package metadata and aligning README wording.

## Changes
- Updated `package.json`:
  - added `engines.node: ">=18"`
  - added `packageManager: "bun@1.3.7"`
- Updated `README.md` runtime requirements section to align wording with metadata:
  - now explicitly references Bun `1.3.7` for repo build/test scripts
- Added required changeset:
  - `.changeset/fancy-candles-end.md`

## Why
README requirements are now machine-readable in package metadata, so consumers and contributors get early, consistent runtime/tooling signals from the package itself.

## Validation
- `bun lint:fix`
- `bun fmt`
- `bun typecheck`
- `bun run test`

All checks passed.

Closes #21
