### PR TITLE
test: add regression coverage for getAtJson inherited keys

### DIFF
--- a/.changeset/quiet-pans-smash.md
+++ b/.changeset/quiet-pans-smash.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Add regression tests for `getAtJson` to ensure inherited properties like `toString`, `hasOwnProperty`, and `__proto__` are treated as missing JSON keys.

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -1156,6 +1156,14 @@ describe("getAtJson", () => {
     expect(getAtJson(data, ["a", "b", "1"])).toBe(2);
   });
 
+  it("treats inherited object properties as missing keys", () => {
+    const data: JsonValue = {};
+
+    expect(() => getAtJson(data, ["toString"])).toThrow("Missing key 'toString'");
+    expect(() => getAtJson(data, ["hasOwnProperty"])).toThrow("Missing key 'hasOwnProperty'");
+    expect(() => getAtJson(data, ["__proto__"])).toThrow("Missing key '__proto__'");
+  });
+
   it("throws on missing object keys", () => {
     const data: JsonValue = { a: 1 };
     expect(() => getAtJson(data, ["b"])).toThrow();


### PR DESCRIPTION
## Summary
- add a regression test ensuring `getAtJson` treats inherited prototype properties as missing JSON keys
- cover `toString`, `hasOwnProperty`, and `__proto__` lookups on plain objects
- include a changeset file per repository PR policy

## Why
Issue #39 reports that inherited properties can be read during JSON pointer traversal. The implementation on `main` already uses own-property checks, but coverage did not explicitly guard these prototype-key lookups. This PR locks that behavior in with targeted tests.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #39