### PR TITLE
fix(state): prevent base-aware array intents from overwriting diverged head nodes

### DIFF
--- a/.changeset/few-socks-agree.md
+++ b/.changeset/few-socks-agree.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Prevent base-aware array intents from coercing a diverged head node into an array. Array insert/delete/replace now return a typed conflict when the head path is no longer an array, and a regression test covers this behavior.

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -351,6 +351,19 @@ describe("clock and state", () => {
     expect(toJson(headWithReplace)).toEqual({ list: ["a", "x", "B"] });
   });
 
+  it("rejects base-aware array inserts when head path diverged to non-array", () => {
+    const base = createState({ a: ["x"] }, { actor: "A" });
+    const head = applyPatch(base, [{ op: "replace", path: "/a", value: { k: 1 } }]);
+
+    const result = tryApplyPatch(head, [{ op: "add", path: "/a/0", value: "y" }], { base });
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("INVALID_TARGET");
+      expect(result.error.path).toBe("/a");
+    }
+  });
+
   it("supports sequential patch semantics against the evolving head", () => {
     const state = createState({ list: [1, 2] }, { actor: "A" });
     const next = applyPatch(state, [{ op: "add", path: "/list/0", value: 99 }], {


### PR DESCRIPTION
## Summary
- add a regression test for explicit-base array insertion when the head path has diverged from array to object
- stop coercing head nodes for base-mapped ArrInsert, ArrDelete, and ArrReplace operations
- return typed conflicts when the head path is missing or no longer an array (INVALID_TARGET for type divergence)
- include a patch changeset for release notes

## Problem
With an explicit base, array intents are compiled from the base snapshot. If the current head had changed the same path to a non-array node, runtime application could coerce that node into a sequence and overwrite unrelated data.

## Fix
Runtime application now validates the head node kind before applying base-mapped array operations. If the head path is not a sequence, the operation returns a conflict instead of mutating the path into an array.

## Testing
- bun run fmt
- bun run lint:fix
- bun run test
- bun run typecheck

Closes #40
