### PR TITLE
fix(state): harden base-aware array remove lineage checks

### DIFF
--- a/.changeset/few-socks-agree.md
+++ b/.changeset/few-socks-agree.md
@@ -2,4 +2,4 @@
 "json-patch-to-crdt": patch
 ---
 
-Prevent base-aware array intents from coercing a diverged head node into an array. Array insert/delete/replace now return a typed conflict when the head path is no longer an array, and a regression test covers this behavior.
+Prevent base-aware array intents from coercing diverged head nodes into arrays, and tighten base-aware `remove` so it fails when the mapped base element is missing from the current head lineage. Duplicate removals remain idempotent, while stale-lineage removals now return typed conflicts.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -715,6 +715,17 @@ function applyArrDelete(
     };
   }
 
+  const e = headSeq.elems.get(baseId);
+  if (!e) {
+    return {
+      ok: false,
+      code: 409,
+      reason: "MISSING_TARGET",
+      message: `element missing in head lineage at index ${it.index}`,
+      path: `/${it.path.join("/")}/${it.index}`,
+    };
+  }
+
   rgaDelete(headSeq, baseId);
 
   return null;

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -364,6 +364,19 @@ describe("clock and state", () => {
     }
   });
 
+  it("rejects base-aware array remove when mapped element is missing in head lineage", () => {
+    const base = createState({ a: ["x"] }, { actor: "A" });
+    const head = applyPatch(base, [{ op: "replace", path: "/a", value: [] }]);
+
+    const result = tryApplyPatch(head, [{ op: "remove", path: "/a/0" }], { base });
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("MISSING_TARGET");
+      expect(result.error.path).toBe("/a/0");
+    }
+  });
+
   it("supports sequential patch semantics against the evolving head", () => {
     const state = createState({ list: [1, 2] }, { actor: "A" });
     const next = applyPatch(state, [{ op: "add", path: "/list/0", value: 99 }], {


### PR DESCRIPTION
## Summary
- reject base-aware array intents when the head path has diverged to a non-array node instead of coercing data
- make ArrDelete fail with MISSING_TARGET when the mapped base element no longer exists in the current head array lineage
- preserve duplicate remove idempotency by allowing already-tombstoned mapped elements to no-op
- add a regression test for stale head-lineage remove behavior and update the existing changeset notes

## Testing
- bun run fmt
- bun run lint:fix
- bun run typecheck
- bun run test

Fixes #41
