### PR TITLE
fix: validate createState/createClock actor and counter invariants

### DIFF
--- a/.changeset/clever-pugs-fix.md
+++ b/.changeset/clever-pugs-fix.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Validate `createClock`/`createState` actor IDs and starting counters up front, throwing a typed `ClockValidationError` for empty actors and invalid counter values instead of allowing states that later fail serialization round-trips.

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
 } from "./state";
 
 export { JsonValueValidationError } from "./json-value";
+export { ClockValidationError } from "./clock";
 
 // JSON helpers
 export { diffJsonPatch } from "./patch";

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -8,7 +8,13 @@ export * from "./index";
 export { applyPatchAsActor } from "./state";
 
 // Clock helpers.
-export { createClock, cloneClock, nextDotForActor, observeDot } from "./clock";
+export {
+  ClockValidationError,
+  createClock,
+  cloneClock,
+  nextDotForActor,
+  observeDot,
+} from "./clock";
 
 // Advanced document/intent helpers.
 export {


### PR DESCRIPTION
## Summary
- validate createClock actor IDs and starting counters so invalid values fail immediately
- make createState inherit the same early validation by reusing createClock
- export a typed ClockValidationError for explicit caller error handling
- add regression tests for invalid actor/counter inputs and a patch changeset entry

## Why
Issue #44 reports that public constructors can create states that later fail serialization/deserialization round-trips because clock invariants were only enforced during deserialization. This change moves those invariant checks to construction time.

## Testing
- bun fmt
- bun lint:fix
- bun test
- bun typecheck

Closes #44
