### PR TITLE
fix: reject cyclic RGA predecessor graphs during deserialization

### DIFF
--- a/.changeset/soft-news-live.md
+++ b/.changeset/soft-news-live.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Reject cyclic RGA predecessor graphs during deserialization and throw a typed invariant error instead of silently dropping unreachable sequence elements.


### PR DESCRIPTION
## Summary
- reject cyclic RGA predecessor graphs during `deserializeDoc` sequence node reconstruction
- preserve existing invariant checks for self-links/missing predecessors and add an explicit acyclicity check
- add a regression test for a two-node predecessor cycle and include a patch changeset

## Why
Malformed serialized sequence data could previously deserialize successfully when predecessor links formed a cycle, which left elements unreachable from `HEAD` and silently dropped during traversal/materialization.

## Changes
- Added `assertAcyclicRgaPredecessors(...)` in `src/serialize.ts` and invoke it after sequence elements are loaded and basic predecessor invariants are validated.
- The new validation throws `DeserializeError` with `reason = "INVALID_SERIALIZED_INVARIANT"` and a typed `path` pointing at the cycle entry predecessor.
- Added serialization regression coverage in `tests/state-core.test.ts` for a 2-node cycle (`A:1 <-> A:2`).
- Added a patch changeset for release notes.

## Validation
- `bun run test:state-core`
- `bun run fmt`
- `bun run lint:fix`
- `bun test`
- `bun run typecheck`

Closes #57
