### PR TITLE
fix: prevent external mutation of rgaLinearizeIds cached output

### DIFF
--- a/.changeset/mean-cameras-drum.md
+++ b/.changeset/mean-cameras-drum.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Prevent external mutation of cached `rgaLinearizeIds` output by returning a copy of the cached linearized ID list.

--- a/src/rga.ts
+++ b/src/rga.ts
@@ -38,7 +38,7 @@ export function rgaLinearizeIds(seq: RgaSeq): ElemId[] {
   const ver = getVersion(seq);
   const cached = linearCache.get(seq);
   if (cached && cached.version === ver) {
-    return cached.ids;
+    return [...cached.ids];
   }
 
   const idx = rgaChildrenIndex(seq);
@@ -68,7 +68,7 @@ export function rgaLinearizeIds(seq: RgaSeq): ElemId[] {
   }
 
   linearCache.set(seq, { version: ver, ids: out });
-  return out;
+  return [...out];
 }
 
 export function rgaInsertAfter(

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -820,6 +820,22 @@ describe("RGA operations", () => {
     expect(rgaLinearizeIds(seq)).toEqual([id2]);
   });
 
+  it("does not allow external mutation of cached linearized ids", () => {
+    const seq = newSeq();
+    const d1 = dot("A", 1);
+    const d2 = dot("A", 2);
+    const id1 = dotToElemId(d1);
+    const id2 = dotToElemId(d2);
+
+    rgaInsertAfter(seq, "HEAD", id1, d1, newReg("a", d1));
+    rgaInsertAfter(seq, id1, id2, d2, newReg("b", d2));
+
+    const ids = rgaLinearizeIds(seq);
+    ids.length = 0;
+
+    expect(rgaLinearizeIds(seq)).toEqual([id1, id2]);
+  });
+
   it("computes prev id for insert at index", () => {
     const seq = newSeq();
     const d1 = dot("A", 1);


### PR DESCRIPTION
## Summary
- add a regression test showing `rgaLinearizeIds` callers can mutate cached linearized IDs via the returned array
- return defensive copies from `rgaLinearizeIds` on both cache hits and fresh linearization results
- add a patch changeset documenting the fix

## Why
`rgaLinearizeIds` cached and returned the same mutable array instance. External callers could mutate that array and corrupt subsequent reads without changing the sequence, which breaks the internal cache contract and can produce incorrect sequence materialization/index lookups.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #58
