### PR TITLE
fix: avoid full base clone in sequential patch compile

### DIFF
--- a/.changeset/fast-sequential-compile-shadow.md
+++ b/.changeset/fast-sequential-compile-shadow.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Optimize sequential JSON Patch intent compilation to avoid cloning the entire base document up front by using copy-on-write shadow updates for touched paths only.


### PR DESCRIPTION
## Summary
Fixes #59 by removing the upfront structuredClone(baseJson) in compileJsonPatchToIntent sequential mode.

Sequential compilation now maintains its shadow document with copy-on-write path cloning (structural sharing), so only touched branches are cloned as operations are applied.

## Changes
- initialize sequential compile shadow from baseJson without cloning the entire document
- replace the shadow updater with a copy-on-write helper that clones only the root and touched path containers
- reuse the same copy-on-write helper in applyPatchOpToJson (used by sequential move compilation)
- add a perf regression test that monkeypatches structuredClone and asserts sequential compilation does not clone the full base document
- add a patch changeset for release notes

## Validation
- bun fmt
- bun lint:fix
- bun typecheck
- bun test
