### PR TITLE
perf(state): optimize sequential apply path shadow execution

### DIFF
--- a/.changeset/green-rice-move.md
+++ b/.changeset/green-rice-move.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Optimize sequential patch application to avoid repeated full JSON materialization and recursive explicit-base shadow replays, including the `move` fast path, while preserving sequential semantics.


### PR DESCRIPTION
## Summary

Closes #60.

This PR optimizes the sequential apply path in `src/state.ts` to reduce repeated full JSON materialization and recursive explicit-base shadow replay work in long patches.

## What Changed

- Keep rolling JSON shadows during sequential execution instead of calling `materialize()` for every operation.
- Replace recursive explicit-base shadow patch replay with direct intent replay into the explicit-base shadow document.
- Preserve explicit-base `move` semantics by compiling the `add` phase against the post-remove head snapshot while maintaining the explicit-base shadow in lockstep.
- Add a perf regression test covering long explicit-base sequential `move` batches.
- Add a patch changeset for the optimization.

## Why

Issue #60 called out sequential-mode runtime costs from:

- per-op rematerialization of full JSON snapshots
- extra rematerialization for `move` add phases
- recursive replay of non-test ops into an explicit-base shadow

This change removes the recursive replay and substantially reduces materialization in the sequential path while keeping existing semantics intact.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`
