### PR TITLE
fix: improve array diff scalability for localized edits

### DIFF
--- a/.changeset/curly-apples-turn.md
+++ b/.changeset/curly-apples-turn.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Improve `diffJsonPatch` array LCS scalability by trimming unchanged array prefixes/suffixes before applying the LCS matrix guardrail, allowing large arrays with small localized edits to produce index-level patches without allocating a full-size matrix.

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -346,10 +346,21 @@ describe("diffJsonPatch", () => {
     expect(ops).toEqual([{ op: "replace", path: "/arr/1", value: 3 }]);
   });
 
-  it("falls back to atomic array replacement for large arrays by default", () => {
+  it("trims unchanged prefixes/suffixes before applying the LCS guardrail", () => {
     const baseArr = Array.from({ length: 600 }, (_, idx) => idx);
     const nextArr = [...baseArr];
     nextArr[300] = -1;
+
+    const base: JsonValue = { arr: baseArr };
+    const next: JsonValue = { arr: nextArr };
+    const ops = diffJsonPatch(base, next);
+
+    expect(ops).toEqual([{ op: "replace", path: "/arr/300", value: -1 }]);
+  });
+
+  it("falls back to atomic array replacement when the unmatched window exceeds the guardrail", () => {
+    const baseArr = Array.from({ length: 600 }, (_, idx) => idx);
+    const nextArr = [...baseArr].reverse();
 
     const base: JsonValue = { arr: baseArr };
     const next: JsonValue = { arr: nextArr };


### PR DESCRIPTION
## Summary
This fixes the large-array diff fallback behavior for arrays that only change in a small localized region.

`diffJsonPatch` previously applied the LCS matrix guardrail using the full array lengths, which caused atomic array replacement even when the arrays shared large unchanged prefixes/suffixes and only a narrow middle window differed.

## Changes
- move the LCS guardrail decision into `diffArray`
- trim unchanged array prefixes/suffixes before sizing the LCS matrix
- run the existing LCS diff only on the unmatched middle window and preserve correct path indices
- keep atomic fallback behavior when the unmatched window still exceeds the guardrail
- add/update perf + doc regression tests for both behaviors
- add a changeset entry

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #62
