### PR TITLE
perf: reduce object diff traversal allocations

### DIFF
--- a/.changeset/blue-rings-share.md
+++ b/.changeset/blue-rings-share.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Reduce `diffJsonPatch` object traversal allocation overhead by reusing a mutable path stack and replacing temporary key-membership `Set` allocations with sorted-key merge scans, while preserving deterministic patch ordering.


### PR DESCRIPTION
## Summary
Closes #63 by reducing allocation overhead in `diffJsonPatch` object traversal without changing default diff output semantics.

## What changed
- Reuse a single mutable path stack throughout recursive diff traversal instead of allocating new path arrays for nested object and array operations.
- Replace temporary object key membership `Set` allocations with sorted-key merge scans for remove/add/shared-key passes.
- Preserve the existing deterministic patch ordering (removes, then adds, then recursive diffs over shared keys).
- Add a patch changeset describing the performance improvement.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`
