### PR TITLE
perf(materialize): reduce traversal allocation pressure

### DIFF
--- a/.changeset/silent-donkeys-bow.md
+++ b/.changeset/silent-donkeys-bow.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Reduce `materialize` traversal allocations by iterating object entries and RGA sequence elements with resumable cursors instead of snapshotting `Array.from(...)` entry lists and per-frame linearized ID arrays.


### PR DESCRIPTION
## Summary
- reduce `materialize` traversal allocations by replacing object-entry `Array.from(...)` snapshots with iterator-backed stack frames
- avoid per-frame sequence ID arrays during materialization by traversing RGA elements with a resumable linear cursor
- add a perf regression test that patches `Array.from` during `toJson` and asserts traversal snapshot allocations are not used

## Details
Issue #64 called out allocation pressure in `materialize` from repeatedly snapshotting object entries and sequence IDs while traversing nested documents.

This PR keeps the explicit stack-based traversal, but changes the frame payloads:
- object frames now store the `Map` iterator directly and consume entries incrementally
- sequence frames now use a new internal `rgaCreateLinearCursor()` helper that preserves the existing depth-first RGA traversal order while yielding live elements incrementally

`rgaLinearizeIds()` is preserved for existing callers and now reuses the same cursor traversal logic.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test`
- `bun run test:perf-regression` (includes new regression test)
- `bun run test:state-core`

## Changeset
- included (`.changeset/silent-donkeys-bow.md`)

Closes #64
