### PR TITLE
feat: add non-throwing deserialize helpers

### DIFF
--- a/.changeset/clean-shrimps-smile.md
+++ b/.changeset/clean-shrimps-smile.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Add non-throwing `tryDeserializeDoc` and `tryDeserializeState` helpers that return structured failures (including typed deserialize and max-depth errors) instead of throwing during CRDT deserialization.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   CreateStateOptions,
   CrdtState,
   CompactStateTombstonesResult,
+  DeserializeFailure,
   DiffOptions,
   DeserializeErrorReason,
   ForkStateOptions,
@@ -25,6 +26,7 @@ export type {
   TombstoneCompactionStats,
   TryApplyPatchInPlaceResult,
   TryApplyPatchResult,
+  TryDeserializeStateResult,
   TryMergeStateResult,
   ValidatePatchResult,
 } from "./types";
@@ -49,7 +51,12 @@ export { ClockValidationError } from "./clock";
 export { diffJsonPatch } from "./patch";
 
 // Serialization
-export { DeserializeError, serializeState, deserializeState } from "./serialize";
+export {
+  DeserializeError,
+  serializeState,
+  deserializeState,
+  tryDeserializeState,
+} from "./serialize";
 
 // Merge
 export { MergeError, mergeState, tryMergeState } from "./merge";

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -49,7 +49,7 @@ export { compactDocTombstones, compactStateTombstones } from "./compact";
 export { mergeDoc, tryMergeDoc } from "./merge";
 
 // Low-level document serialization helpers.
-export { serializeDoc, deserializeDoc } from "./serialize";
+export { serializeDoc, deserializeDoc, tryDeserializeDoc } from "./serialize";
 
 // Internals-only types.
 export type {
@@ -60,6 +60,7 @@ export type {
   CompactDocTombstonesResult,
   CompactStateTombstonesResult,
   CompilePatchOptions,
+  DeserializeFailure,
   Doc,
   Dot,
   ElemId,
@@ -78,6 +79,7 @@ export type {
   SerializedRgaElem,
   TombstoneCompactionOptions,
   TombstoneCompactionStats,
+  TryDeserializeDocResult,
   TryMergeDocResult,
   VersionVector,
 } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,22 @@ export type SerializedState = { doc: SerializedDoc; clock: SerializedClock };
 /** Typed reasons for rejecting malformed serialized CRDT payloads. */
 export type DeserializeErrorReason = "INVALID_SERIALIZED_SHAPE" | "INVALID_SERIALIZED_INVARIANT";
 
+/** Structured failure payload used by non-throwing deserialize helpers. */
+export type DeserializeFailure =
+  | {
+      code: 409;
+      reason: DeserializeErrorReason;
+      path: string;
+      message: string;
+    }
+  | {
+      code: 409;
+      reason: "MAX_DEPTH_EXCEEDED";
+      message: string;
+      depth: number;
+      maxDepth: number;
+    };
+
 // ---
 
 /**
@@ -223,6 +239,16 @@ export type ApplyError = {
 
 /** Result of applying a patch: success or structured conflict details. */
 export type ApplyResult = { ok: true } | ApplyError;
+
+/** Non-throwing result for `deserializeDoc`. */
+export type TryDeserializeDocResult =
+  | { ok: true; doc: Doc }
+  | { ok: false; error: DeserializeFailure };
+
+/** Non-throwing result for `deserializeState`. */
+export type TryDeserializeStateResult =
+  | { ok: true; state: CrdtState }
+  | { ok: false; error: DeserializeFailure };
 
 /** How JSON Patch operations are interpreted during application. */
 export type PatchSemantics = "base" | "sequential";


### PR DESCRIPTION
## Summary
- add non-throwing deserialization helpers for document and state payloads
- mirror the existing `try*` API result pattern used by patch/merge helpers
- return structured failures for malformed serialized input and max-depth traversal failures

## Changes
- add `tryDeserializeDoc(...)` in `src/serialize.ts` and export it from `src/internals.ts`
- add `tryDeserializeState(...)` in `src/serialize.ts` and export it from the public entrypoint (`src/index.ts`)
- add `DeserializeFailure`, `TryDeserializeDocResult`, and `TryDeserializeStateResult` types
- extend serialization tests to cover non-throwing doc/state failures and depth-error behavior
- add a changeset for the new APIs

## Error behavior
The new helpers return `{ ok: false, error }` for:
- `DeserializeError` (preserving `code`, `reason`, `path`, `message`)
- `TraversalDepthError` (preserving `code`, `reason`, `depth`, `maxDepth`, `message`)

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`

Closes #65
