### PR TITLE
feat: add tryApplyPatchAsActor internals helper

### DIFF
--- a/.changeset/four-snakes-tickle.md
+++ b/.changeset/four-snakes-tickle.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": minor
+---
+
+Add `tryApplyPatchAsActor` to the internals API as a non-throwing counterpart to `applyPatchAsActor`, returning structured apply errors while preserving the existing throwing helper.

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -5,7 +5,7 @@
 export * from "./index";
 
 // Advanced state helper.
-export { applyPatchAsActor } from "./state";
+export { applyPatchAsActor, tryApplyPatchAsActor } from "./state";
 
 // Clock helpers.
 export {
@@ -55,6 +55,7 @@ export { serializeDoc, deserializeDoc, tryDeserializeDoc } from "./serialize";
 export type {
   ApplyPatchAsActorResult,
   ApplyPatchAsActorOptions,
+  TryApplyPatchAsActorResult,
   ApplyResult,
   Clock,
   CompactDocTombstonesResult,

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,11 @@ export type ApplyPatchAsActorOptions = {
   jsonValidation?: JsonValidationMode;
 };
 
+/** Non-throwing result for internals-only `tryApplyPatchAsActor`. */
+export type TryApplyPatchAsActorResult =
+  | ({ ok: true } & ApplyPatchAsActorResult)
+  | { ok: false; error: ApplyError };
+
 /** Typed failure reason used across patch/merge helpers. */
 export type PatchErrorReason =
   | "INVALID_PATCH"


### PR DESCRIPTION
## Summary
- add tryApplyPatchAsActor as a non-throwing internals API that mirrors applyPatchAsActor success payloads and returns structured apply errors on failure
- refactor applyPatchAsActor to delegate to the new try helper so clock recovery and version-vector updates stay aligned
- export the helper and result type from src/internals.ts, add tests for success plus typed failure behavior, and include a changeset

## Testing
- bun fmt
- bun lint:fix
- bun test
- bun typecheck

Closes #66