### PR TITLE
fix: repair stale deserializeState clock counters

### DIFF
--- a/.changeset/fuzzy-houses-think.md
+++ b/.changeset/fuzzy-houses-think.md
@@ -1,0 +1,7 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Repair `deserializeState` clock restoration by lifting stale serialized actor counters to the
+highest dot already present in the deserialized document, preventing duplicate dot generation
+after restart. Includes a regression test for tampered serialized clock metadata.

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -104,8 +104,9 @@ export function deserializeState(data: SerializedState): CrdtState {
   const clockRaw = asRecord(data.clock, "/clock");
   const actor = readActor(clockRaw.actor, "/clock/actor");
   const ctr = readCounter(clockRaw.ctr, "/clock/ctr");
-  const clock = createClock(actor, ctr);
   const doc = deserializeDoc(data.doc);
+  const observedCtr = maxObservedCounterForActorInNode(doc.root, actor);
+  const clock = createClock(actor, Math.max(ctr, observedCtr));
   return { doc, clock };
 }
 
@@ -308,6 +309,43 @@ function assertAcyclicRgaPredecessors(elems: Map<string, RgaElem>, path: string)
       visitState.set(id, 2);
     }
   }
+}
+
+function maxObservedCounterForActorInNode(node: Node, actor: string): number {
+  if (node.kind === "lww") {
+    return node.dot.actor === actor ? node.dot.ctr : 0;
+  }
+
+  if (node.kind === "obj") {
+    let maxCtr = 0;
+
+    for (const entry of node.entries.values()) {
+      if (entry.dot.actor === actor) {
+        maxCtr = Math.max(maxCtr, entry.dot.ctr);
+      }
+
+      maxCtr = Math.max(maxCtr, maxObservedCounterForActorInNode(entry.node, actor));
+    }
+
+    for (const tombstoneDot of node.tombstone.values()) {
+      if (tombstoneDot.actor === actor) {
+        maxCtr = Math.max(maxCtr, tombstoneDot.ctr);
+      }
+    }
+
+    return maxCtr;
+  }
+
+  let maxCtr = 0;
+  for (const elem of node.elems.values()) {
+    if (elem.insDot.actor === actor) {
+      maxCtr = Math.max(maxCtr, elem.insDot.ctr);
+    }
+
+    maxCtr = Math.max(maxCtr, maxObservedCounterForActorInNode(elem.value, actor));
+  }
+
+  return maxCtr;
 }
 
 function asRecord(value: unknown, path: string): Record<string, unknown> {

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -1109,6 +1109,23 @@ describe("serialization", () => {
     expect(toJson(next)).toEqual({ a: 2 });
   });
 
+  it("repairs stale serialized clock counters during state deserialization", () => {
+    const base = createState({ a: 1 }, { actor: "A" });
+    const state = applyPatch(base, [{ op: "add", path: "/b", value: 2 }]);
+    const payload = serializeState(state);
+
+    payload.clock.ctr = Math.max(0, state.clock.ctr - 1);
+
+    const restored = deserializeState(payload);
+
+    expect(restored.clock.actor).toBe("A");
+    expect(restored.clock.ctr).toBe(state.clock.ctr);
+
+    const next = applyPatch(restored, [{ op: "replace", path: "/a", value: 3 }]);
+    expect(toJson(next)).toEqual({ a: 3, b: 2 });
+    expect(next.clock.ctr).toBeGreaterThan(state.clock.ctr);
+  });
+
   it("rejects sequence elements whose key does not match element id", () => {
     const malformed = {
       root: {


### PR DESCRIPTION
## Summary
- repair `deserializeState` clock restoration by lifting the serialized actor counter to the highest dot already present in the deserialized document
- scan nested CRDT nodes (object entry dots, object tombstones, sequence insertion dots, and nested values) when computing the observed max counter
- add a regression test covering tampered serialized clock metadata and include a patch changeset

## Problem
`deserializeState()` previously trusted the serialized clock counter. If serialized state was manually edited or malformed and the stored counter lagged behind dots already present in the document, the next mutation could generate duplicate dots for that actor.

## Fix
Deserialize the document first, compute the maximum observed counter for the restored actor across the document tree, and initialize the clock with `max(serializedCtr, observedCtr)`.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #79
