### PR TITLE
feat(internals): add RGA validation and checked insert APIs

### DIFF
--- a/.changeset/quick-ants-guard.md
+++ b/.changeset/quick-ants-guard.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Add internals RGA validation helpers and a checked insert API to detect missing predecessors, cycles, and orphaned elements in custom sequence construction.

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -98,9 +98,13 @@ export { newObj, newSeq, newReg, lwwSet, objSet, objRemove, objCompactTombstones
 export {
   HEAD,
   rgaInsertAfter,
+  rgaInsertAfterChecked,
   rgaDelete,
   rgaCompactTombstones,
   rgaLinearizeIds,
   rgaPrevForInsertAtIndex,
   rgaIdAtIndex,
+  validateRgaSeq,
 } from "./rga";
+
+export type { RgaValidationIssue, RgaValidationResult } from "./rga";


### PR DESCRIPTION
## Summary
- add `rgaInsertAfterChecked(...)` for internals users to fail fast on missing predecessor IDs
- add `validateRgaSeq(seq)` with structured issue reporting for missing predecessors, predecessor cycles, and orphaned/unreachable elements
- add regression tests that demonstrate invalid sequences can be detected deterministically even when `rgaLinearizeIds()` would otherwise return an incomplete view
- add a changeset for the internals API addition

## Why
Issue #80 calls out that advanced `json-patch-to-crdt/internals` consumers can construct invalid RGA sequences (for example, with missing predecessors) and traversal silently drops unreachable elements. This PR adds explicit validation and a safer checked insert helper without changing existing `rgaInsertAfter()` behavior.

## Implementation notes
- `rgaInsertAfterChecked()` preserves duplicate-insert idempotence, but throws when inserting a new element whose `prev` is neither `HEAD` nor an existing element id.
- `validateRgaSeq()` returns structured issues and reports:
  - `MISSING_PREDECESSOR`
  - `PREDECESSOR_CYCLE`
  - `ORPHANED_ELEMENT`
- new helpers and types are exported from `src/internals.ts`
- issue ordering is deterministic to keep tests stable

## Tests
- `bun run fmt`
- `bun run lint:fix`
- `bun test`
- `bun run typecheck`

Closes #80
