### PR TITLE
perf(rga): cache max sibling insert dots

### DIFF
--- a/.changeset/swift-bottles-bake.md
+++ b/.changeset/swift-bottles-bake.md
@@ -1,0 +1,7 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Optimize array insert dot allocation by caching the max sibling insert dot per predecessor so
+repeated inserts no longer rescan the full RGA sequence. Includes a performance regression test
+covering repeated append workloads.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -34,6 +34,7 @@ import {
   rgaIdAtIndex,
   rgaInsertAfter,
   rgaLinearizeIds,
+  rgaMaxInsertDotForPrev,
   rgaPrevForInsertAtIndex,
 } from "./rga";
 import { ROOT_KEY } from "./types";
@@ -692,16 +693,7 @@ function nextInsertDotForPrev(
   bumpCounterAbove?: (ctr: number) => void,
 ): { ok: true; dot: Dot } | ApplyError {
   const MAX_INSERT_DOT_ATTEMPTS = 1_024;
-  let maxSiblingDot: Dot | null = null;
-  for (const elem of seq.elems.values()) {
-    if (elem.prev !== prev) {
-      continue;
-    }
-
-    if (!maxSiblingDot || compareDot(elem.insDot, maxSiblingDot) > 0) {
-      maxSiblingDot = elem.insDot;
-    }
-  }
+  const maxSiblingDot = rgaMaxInsertDotForPrev(seq, prev);
 
   if (maxSiblingDot) {
     // Fast-forward external counters so generated dots can stay strictly after


### PR DESCRIPTION
## Summary
- cache the max sibling insert dot per RGA predecessor to avoid rescanning the full sequence in `nextInsertDotForPrev()`
- update the cache incrementally on inserts and invalidate it when tombstone compaction removes sequence elements
- add a performance regression test that instruments `seq.elems.values()` during repeated appends and proves we no longer scan per insert
- add a patch changeset entry

## Why
Issue #81 identifies `nextInsertDotForPrev()` as an `O(n)` hot path for append-heavy array workloads because it scans `seq.elems.values()` on every insert to find the max sibling `insDot` for the same predecessor.

This PR moves that lookup to a lazy per-sequence cache in `src/rga.ts`, so repeated inserts after the same predecessor reuse cached metadata and only pay the scan once (until the cache is invalidated).

## Implementation Notes
- New `WeakMap<RgaSeq, Map<ElemId, Dot>>` cache in `src/rga.ts`
- Cache is lazily built on first lookup (`rgaMaxInsertDotForPrev`)
- `rgaInsertAfter` updates cached predecessor maxima when a cache entry already exists
- `rgaCompactTombstones` invalidates the cache because physical removals can delete the current max sibling
- `src/doc.ts` now calls `rgaMaxInsertDotForPrev()` instead of scanning `seq.elems`

## Testing
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`

Closes #81
