### PR TITLE
perf(rga): reduce repeated indexed lookup linearization

### DIFF
--- a/.changeset/green-cats-tickle.md
+++ b/.changeset/green-cats-tickle.md
@@ -1,0 +1,8 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Reduce repeated indexed-array RGA lookups during intent application by reusing per-sequence
+index snapshots across an apply session and incrementally updating them when base and head share
+the same evolving array. Includes a perf regression test covering repeated indexed deletes on an
+evolving base snapshot.


### PR DESCRIPTION
## Summary
- add `rgaCreateIndexedIdSnapshot()` to capture a reusable linearized ID snapshot for indexed RGA lookups
- reuse per-sequence indexed snapshots during `applyIntentsToCrdt()` so `ArrInsert`/`ArrDelete`/`ArrReplace` stop rebuilding full ID arrays on repeated lookups in one apply session
- keep snapshots aligned when `base` and `head` share the same evolving sequence by updating cached IDs after inserts/deletes
- add a performance regression test covering repeated indexed deletes against an evolving `base === head` array
- include a patch changeset entry

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun run test`

Closes #82