### PR TITLE
refactor: deduplicate benchmark env parsing

### DIFF
--- a/.changeset/late-gorillas-laugh.md
+++ b/.changeset/late-gorillas-laugh.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Deduplicate benchmark environment parsing by introducing a shared `parsePositiveIntEnv` helper used across the object diff, CRDT diff, and sequential apply microbenchmarks.

--- a/bench/crdt-diff.microbench.ts
+++ b/bench/crdt-diff.microbench.ts
@@ -9,6 +9,7 @@ import {
   type JsonPatchOp,
   type JsonValue,
 } from "../src/internals";
+import { parsePositiveIntEnv } from "./utils";
 
 type BenchmarkStats = {
   name: string;
@@ -18,20 +19,6 @@ type BenchmarkStats = {
   p50Ms: number;
   avgHeapDeltaMb: number;
 };
-
-function parsePositiveIntEnv(name: string, fallback: number): number {
-  const raw = Bun.env[name];
-  if (!raw) {
-    return fallback;
-  }
-
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
-    throw new Error(`${name} must be a positive integer, got '${raw}'`);
-  }
-
-  return parsed;
-}
 
 function percentile(sortedValues: number[], p: number): number {
   const pos = Math.floor((sortedValues.length - 1) * p);

--- a/bench/object-diff.microbench.ts
+++ b/bench/object-diff.microbench.ts
@@ -1,4 +1,5 @@
 import { diffJsonPatch, type JsonPatchOp, type JsonValue } from "../src/internals";
+import { parsePositiveIntEnv } from "./utils";
 
 type BenchmarkStats = {
   readonly name: string;
@@ -8,20 +9,6 @@ type BenchmarkStats = {
   readonly p50Ms: number;
   readonly avgHeapDeltaMb: number;
 };
-
-function parsePositiveIntEnv(name: string, fallback: number): number {
-  const raw = Bun.env[name];
-  if (!raw) {
-    return fallback;
-  }
-
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
-    throw new Error(`${name} must be a positive integer, got '${raw}'`);
-  }
-
-  return parsed;
-}
 
 function percentile(sortedValues: number[], p: number): number {
   const pos = Math.floor((sortedValues.length - 1) * p);

--- a/bench/sequential-apply.microbench.ts
+++ b/bench/sequential-apply.microbench.ts
@@ -12,6 +12,7 @@ import {
   type JsonPatchOp,
   type JsonValue,
 } from "../src/internals";
+import { parsePositiveIntEnv } from "./utils";
 
 type BenchmarkStats = {
   name: string;
@@ -28,20 +29,6 @@ type BenchmarkScenario = {
   patchLength: number;
   runs: number;
 };
-
-function parsePositiveIntEnv(name: string, fallback: number): number {
-  const raw = Bun.env[name];
-  if (!raw) {
-    return fallback;
-  }
-
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
-    throw new Error(`${name} must be a positive integer, got '${raw}'`);
-  }
-
-  return parsed;
-}
 
 function buildBaseDocument(size: number): JsonValue {
   return {

--- a/bench/utils.ts
+++ b/bench/utils.ts
@@ -1,0 +1,13 @@
+export function parsePositiveIntEnv(name: string, fallback: number): number {
+  const raw = Bun.env[name];
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    throw new Error(`${name} must be a positive integer, got '${raw}'`);
+  }
+
+  return parsed;
+}


### PR DESCRIPTION
## Summary
- extract `parsePositiveIntEnv` into a shared `bench/utils.ts` helper
- update the CRDT diff, object diff, and sequential apply microbenchmarks to use the shared helper
- add the required changeset for the benchmark cleanup

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

## Notes
- this change only affects benchmark utilities and benchmark scripts; runtime library behavior is unchanged