### PR TITLE
fix: include sequence delete dots in counter recovery

### DIFF
--- a/.changeset/four-ravens-scan.md
+++ b/.changeset/four-ravens-scan.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Include RGA sequence delete dots when recovering actor counters during state deserialization, `applyPatchAsActor`, and `mergeState` so resumed writes do not reuse prior actor counters after array deletions.

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -244,6 +244,9 @@ function maxCtrInNodeForActor(node: Node, actor: ActorId): number {
       if (elem.insDot.actor === actor && elem.insDot.ctr > best) {
         best = elem.insDot.ctr;
       }
+      if (elem.delDot?.actor === actor && elem.delDot.ctr > best) {
+        best = elem.delDot.ctr;
+      }
       stack.push({ node: elem.value, depth: frame.depth + 1 });
     }
   }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -359,6 +359,10 @@ function maxObservedCounterForActorInNode(node: Node, actor: string): number {
       maxCtr = Math.max(maxCtr, elem.insDot.ctr);
     }
 
+    if (elem.delDot?.actor === actor) {
+      maxCtr = Math.max(maxCtr, elem.delDot.ctr);
+    }
+
     maxCtr = Math.max(maxCtr, maxObservedCounterForActorInNode(elem.value, actor));
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -970,6 +970,9 @@ function maxCtrInNodeForActor(node: Node, actor: ActorId): number {
       if (elem.insDot.actor === actor && elem.insDot.ctr > best) {
         best = elem.insDot.ctr;
       }
+      if (elem.delDot?.actor === actor && elem.delDot.ctr > best) {
+        best = elem.delDot.ctr;
+      }
       stack.push({ node: elem.value, depth: frame.depth + 1 });
     }
   }

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -536,6 +536,31 @@ describe("mergeState", () => {
     expect(result.items).toContain("fromA2");
     expect(result.items).toContain("fromB2");
   });
+
+  it("recovers mergeState actor clocks from sequence delete dots", () => {
+    const base = createState({ list: [1] }, { actor: "A" });
+    const deleted = applyPatch(base, [{ op: "remove", path: "/list/0" }]);
+    const staleDeleted: CrdtState = {
+      doc: cloneDoc(deleted.doc),
+      clock: createClock("A", 3),
+    };
+    const peer = forkState(base, "B");
+
+    const merged = mergeState(staleDeleted, peer, { actor: "A" });
+
+    expect(toJson(merged)).toEqual({ list: [] });
+    expect(merged.clock.actor).toBe("A");
+    expect(merged.clock.ctr).toBe(4);
+
+    const next = applyPatch(merged, [{ op: "add", path: "/x", value: 1 }]);
+    expect(toJson(next)).toEqual({ list: [], x: 1 });
+    if (next.doc.root.kind !== "obj") {
+      throw new Error("Expected object root");
+    }
+
+    expect(next.doc.root.entries.get("x")?.dot).toEqual({ actor: "A", ctr: 5 });
+    expect(next.clock.ctr).toBe(6);
+  });
 });
 
 describe("tombstone compaction", () => {

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -615,6 +615,30 @@ describe("clock and state", () => {
     expect(next.vv["A"]).toBe(next.state.clock.ctr);
   });
 
+  it("recovers stale actor counters from sequence delete dots in applyPatchAsActor", () => {
+    const base = createState({ list: [1] }, { actor: "A" });
+    const deleted = applyPatch(base, [{ op: "remove", path: "/list/0" }]);
+
+    const resumed = applyPatchAsActor(deleted.doc, {}, "A", [{ op: "add", path: "/x", value: 1 }]);
+
+    expect(toJson(resumed.state)).toEqual({ list: [], x: 1 });
+    if (resumed.state.doc.root.kind !== "obj") {
+      throw new Error("Expected object root");
+    }
+
+    const listNode = resumed.state.doc.root.entries.get("list")?.node;
+    const xEntry = resumed.state.doc.root.entries.get("x");
+    if (!listNode || listNode.kind !== "seq" || !xEntry) {
+      throw new Error("Expected list sequence and x entry");
+    }
+
+    const deletedElem = listNode.elems.get("A:2");
+    expect(deletedElem?.delDot).toEqual({ actor: "A", ctr: 4 });
+    expect(xEntry.dot).toEqual({ actor: "A", ctr: 5 });
+    expect(resumed.state.clock.ctr).toBe(6);
+    expect(resumed.vv["A"]).toBe(6);
+  });
+
   it("exposes a non-throwing applyPatchAsActor helper", () => {
     const doc = docFromJson({ list: ["a"] }, newDotGen("origin", 0));
     const vv: VersionVector = {};
@@ -1238,6 +1262,28 @@ describe("serialization", () => {
     const next = applyPatch(restored, [{ op: "replace", path: "/a", value: 3 }]);
     expect(toJson(next)).toEqual({ a: 3, b: 2 });
     expect(next.clock.ctr).toBeGreaterThan(state.clock.ctr);
+  });
+
+  it("repairs stale serialized clocks from sequence delete dots during deserialization", () => {
+    const base = createState({ list: [1] }, { actor: "A" });
+    const deleted = applyPatch(base, [{ op: "remove", path: "/list/0" }]);
+    const payload = serializeState(deleted);
+
+    payload.clock.ctr = 0;
+
+    const restored = deserializeState(payload);
+
+    expect(restored.clock.actor).toBe("A");
+    expect(restored.clock.ctr).toBe(4);
+
+    const next = applyPatch(restored, [{ op: "add", path: "/x", value: 1 }]);
+    expect(toJson(next)).toEqual({ list: [], x: 1 });
+    if (next.doc.root.kind !== "obj") {
+      throw new Error("Expected object root");
+    }
+
+    expect(next.doc.root.entries.get("x")?.dot).toEqual({ actor: "A", ctr: 5 });
+    expect(next.clock.ctr).toBe(6);
   });
 
   it("rejects sequence elements whose key does not match element id", () => {


### PR DESCRIPTION
## Summary
- include RGA sequence `delDot` values when recovering the highest observed counter for an actor
- add regression coverage for `applyPatchAsActor`, `deserializeState`, and `mergeState({ actor })`
- add a patch changeset for the counter-recovery fix

## Problem
Issue #104 describes stale counter recovery paths that scan object tombstones and insert dots but skip sequence delete dots. That allows resumed writes to reuse a prior actor counter after an array deletion.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun test`

Fixes #104