### PR TITLE
fix: escape merge lineage pointers for escaped keys

### DIFF
--- a/.changeset/swift-camels-relax.md
+++ b/.changeset/swift-camels-relax.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Escape merge lineage error pointers with RFC 6901 encoding so `tryMergeDoc`, `mergeDoc`, and related shared-element merge diagnostics report unambiguous paths for keys containing `/` or `~`.

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -19,6 +19,7 @@ import type {
 import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth, toDepthApplyError } from "./depth";
 import { compareDot } from "./dot";
+import { stringifyJsonPointer } from "./patch";
 
 class SharedElementMetadataMismatchError extends Error {
   readonly path: string;
@@ -72,7 +73,7 @@ export function tryMergeDoc(a: Doc, b: Doc, options: MergeDocOptions = {}): TryM
   try {
     const requireSharedOrigin = options.requireSharedOrigin ?? true;
     const mismatchPath = requireSharedOrigin ? findSeqLineageMismatch(a.root, b.root, []) : null;
-    if (mismatchPath) {
+    if (mismatchPath !== null) {
       return {
         ok: false,
         error: {
@@ -169,7 +170,7 @@ function findSeqLineageMismatch(a: Node, b: Node, path: string[]): string | null
         }
 
         if (!shared) {
-          return `/${frame.path.join("/")}`;
+          return stringifyJsonPointer(frame.path);
         }
       }
     }
@@ -364,11 +365,11 @@ function mergeSeq(a: RgaSeq, b: RgaSeq, depth: number, path: string[]): RgaSeq {
 
     if (ea && eb) {
       if (ea.prev !== eb.prev) {
-        throw new SharedElementMetadataMismatchError(toPointer(path), id, "prev");
+        throw new SharedElementMetadataMismatchError(stringifyJsonPointer(path), id, "prev");
       }
 
       if (!sameDot(ea.insDot, eb.insDot)) {
-        throw new SharedElementMetadataMismatchError(toPointer(path), id, "insDot");
+        throw new SharedElementMetadataMismatchError(stringifyJsonPointer(path), id, "insDot");
       }
 
       // Both sides have this element. Merge:
@@ -396,14 +397,6 @@ function mergeSeq(a: RgaSeq, b: RgaSeq, depth: number, path: string[]): RgaSeq {
 
 function sameDot(a: Dot, b: Dot): boolean {
   return a.actor === b.actor && a.ctr === b.ctr;
-}
-
-function toPointer(path: string[]): string {
-  if (path.length === 0) {
-    return "/";
-  }
-
-  return `/${path.join("/")}`;
 }
 
 function cloneElem(e: RgaElem, depth: number): RgaElem {

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -286,6 +286,30 @@ describe("mergeDoc", () => {
     }
   });
 
+  it("escapes shared-origin lineage mismatch paths under escaped object keys", () => {
+    const expectedPath = stringifyJsonPointer(["a~b", "c/d"]);
+    const a = docFromJson({ "a~b": { "c/d": [1] } }, newDotGen("A"));
+    const b = docFromJson({ "a~b": { "c/d": [1] } }, newDotGen("B"));
+
+    const res = tryMergeDoc(a, b);
+    expect(res.ok).toBeFalse();
+    if (!res.ok) {
+      expect(res.error.reason).toBe("LINEAGE_MISMATCH");
+      expect(res.error.path).toBe(expectedPath);
+      expect(res.error.message).toContain(expectedPath);
+    }
+
+    expect(() => mergeDoc(a, b)).toThrow(MergeError);
+    try {
+      mergeDoc(a, b);
+    } catch (error) {
+      expect(error).toBeInstanceOf(MergeError);
+      if (error instanceof MergeError) {
+        expect(error.path).toBe(expectedPath);
+      }
+    }
+  });
+
   it("allows merging unrelated arrays when shared-origin checks are disabled", () => {
     const a = docFromJson([1], newDotGen("A"));
     const b = docFromJson([1], newDotGen("B"));
@@ -329,6 +353,50 @@ describe("mergeDoc", () => {
     }
 
     expect(() => mergeDoc(a, b)).toThrow(MergeError);
+  });
+
+  it("escapes shared RGA metadata mismatch paths under escaped object keys", () => {
+    const expectedPath = stringifyJsonPointer(["a~b", "c/d"]);
+    const origin = createState({ "a~b": { "c/d": ["a", "b"] } }, { actor: "origin" });
+    const a = cloneDoc(origin.doc);
+    const b = cloneDoc(origin.doc);
+
+    if (a.root.kind !== "obj" || b.root.kind !== "obj") {
+      throw new Error("Expected object roots");
+    }
+
+    const nestedA = a.root.entries.get("a~b")?.node;
+    const nestedB = b.root.entries.get("a~b")?.node;
+    if (!nestedA || !nestedB || nestedA.kind !== "obj" || nestedB.kind !== "obj") {
+      throw new Error("Expected nested object nodes");
+    }
+
+    const seqA = nestedA.entries.get("c/d")?.node;
+    const seqB = nestedB.entries.get("c/d")?.node;
+    if (!seqA || !seqB || seqA.kind !== "seq" || seqB.kind !== "seq") {
+      throw new Error("Expected nested list sequences");
+    }
+
+    const ids = rgaLinearizeIds(seqA);
+    const secondId = ids[1];
+    if (!secondId) {
+      throw new Error("Expected second element id");
+    }
+
+    const corrupted = seqB.elems.get(secondId);
+    if (!corrupted) {
+      throw new Error("Expected shared element in second sequence");
+    }
+    corrupted.prev = HEAD;
+
+    const res = tryMergeDoc(a, b);
+    expect(res.ok).toBeFalse();
+    if (!res.ok) {
+      expect(res.error.reason).toBe("LINEAGE_MISMATCH");
+      expect(res.error.path).toBe(expectedPath);
+      expect(res.error.message).toContain("prev");
+      expect(res.error.message).toContain(secondId);
+    }
   });
 
   it("rejects shared RGA ids when insertion dots disagree", () => {


### PR DESCRIPTION
## Summary
- route merge lineage mismatch paths through RFC 6901 pointer stringification so keys containing \/ or ~ are escaped consistently
- preserve root-level shared-origin detection when the lineage pointer is the empty string
- add regression tests for shared-origin and shared RGA metadata mismatches under escaped object keys

## Testing
- bun run fmt
- bun run lint:fix
- bun test
- bun run typecheck

Closes #102