### PR TITLE
Add worst-case runtime guardrails for lcs-linear array diffs

### DIFF
--- a/.changeset/green-poets-travel.md
+++ b/.changeset/green-poets-travel.md
@@ -1,0 +1,7 @@
+---
+"json-patch-to-crdt": minor
+---
+
+Add an opt-in `lcsLinearMaxCells` diff option so `arrayStrategy: "lcs-linear"` can fall back to an
+atomic array `replace` when the trimmed unmatched window would otherwise trigger worst-case
+`O(n * m)` work.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ For array-heavy snapshots, `diffJsonPatch` and `crdtToJsonPatch` support:
 - `arrayStrategy: "lcs-linear"`: deterministic index-level array edits using a lower-memory linear-space LCS traversal.
 - `arrayStrategy: "atomic"`: replace the whole array with a single patch operation.
 
-`lcsMaxCells` only applies to `arrayStrategy: "lcs"`. If the classic LCS matrix would exceed the configured cap, the diff falls back to an atomic array `replace`. Use `lcs-linear` when you want index-level patches for larger arrays without allocating the full matrix, but note that it still has `O(n * m)` time complexity and does not automatically fall back for very large unmatched windows.
+`lcsMaxCells` only applies to `arrayStrategy: "lcs"`. If the classic LCS matrix for the trimmed unmatched window would exceed the configured cap, the diff falls back to an atomic array `replace`.
+
+`lcsLinearMaxCells` is the matching opt-in guardrail for `arrayStrategy: "lcs-linear"`. It uses the same trimmed unmatched-window estimate, but caps worst-case runtime instead of matrix allocation. When the cap is exceeded, `lcs-linear` also falls back to an atomic array `replace`. If you do not set `lcsLinearMaxCells`, `lcs-linear` keeps its previous behavior and will continue to run without an automatic fallback.
 
 `diffJsonPatch` keeps the existing `add`/`remove`/`replace` output by default. Set
 `emitMoves` and/or `emitCopies` to opt into deterministic RFC 6902 `move`/`copy`

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -273,8 +273,8 @@ export function compileJsonPatchOpToIntent(
  * By default arrays use a deterministic LCS strategy.
  * Pass `{ arrayStrategy: "atomic" }` for single-op array replacement.
  * Pass `{ arrayStrategy: "lcs-linear" }` for a lower-memory LCS variant.
- * Note that `lcs-linear` still runs in `O(n * m)` time and does not have an
- * automatic fallback for very large unmatched windows.
+ * Use `lcsLinearMaxCells` to optionally cap worst-case `lcs-linear` work and
+ * fall back to an atomic array replacement for very large unmatched windows.
  * Pass `{ emitMoves: true }` or `{ emitCopies: true }` to opt into RFC 6902
  * move/copy emission when a deterministic rewrite is available.
  * @param base - The original JSON value.
@@ -364,7 +364,9 @@ function diffValue(
       }
 
       if (arrayStrategy === "lcs-linear") {
-        diffArrayWithLinearLcs(path, frame.base, frame.next, ops, options);
+        if (!diffArrayWithLinearLcs(path, frame.base, frame.next, ops, options)) {
+          ops.push({ op: "replace", path: stringifyJsonPointer(path), value: frame.next });
+        }
         continue;
       }
 
@@ -652,8 +654,12 @@ function diffArrayWithLinearLcs(
   next: JsonValue[],
   ops: JsonPatchOp[],
   options: DiffOptions,
-): void {
+): boolean {
   const window = trimEqualArrayEdges(base, next);
+  if (!shouldUseLinearLcsDiff(window.unmatchedBaseLength, window.unmatchedNextLength, options)) {
+    return false;
+  }
+
   const steps: ArrayDiffStep[] = [];
   buildArrayEditScriptLinearSpace(
     base,
@@ -666,6 +672,7 @@ function diffArrayWithLinearLcs(
   );
 
   pushArrayPatchOps(path, window.prefixLength, steps, ops, base, options);
+  return true;
 }
 
 function trimEqualArrayEdges(base: JsonValue[], next: JsonValue[]): TrimmedArrayWindow {
@@ -1033,6 +1040,24 @@ function shouldUseLcsDiff(baseLength: number, nextLength: number, lcsMaxCells?: 
 
   const matrixCells = (baseLength + 1) * (nextLength + 1);
   return matrixCells <= cap;
+}
+
+function shouldUseLinearLcsDiff(
+  baseLength: number,
+  nextLength: number,
+  options: DiffOptions,
+): boolean {
+  const cap = options.lcsLinearMaxCells;
+  if (cap === undefined || cap === Number.POSITIVE_INFINITY) {
+    return true;
+  }
+
+  if (!Number.isFinite(cap) || cap < 1) {
+    return false;
+  }
+
+  const estimatedCells = (baseLength + 1) * (nextLength + 1);
+  return estimatedCells <= cap;
 }
 
 function finalizeArrayOps(

--- a/src/types.ts
+++ b/src/types.ts
@@ -424,6 +424,19 @@ export type DiffOptions = {
    */
   lcsMaxCells?: number;
   /**
+   * Optional guardrail for `arrayStrategy: "lcs-linear"`.
+   * Uses the trimmed unmatched window size
+   * (`(unmatchedBase.length + 1) * (unmatchedNext.length + 1)`) as a proxy for
+   * worst-case work. When the cap is exceeded, the diff falls back to an atomic
+   * array replacement instead of running the linear-space traversal.
+   *
+   * Unlike `lcsMaxCells`, this is opt-in and defaults to no fallback so
+   * existing `lcs-linear` callers keep their current behavior.
+   *
+   * Set to `Number.POSITIVE_INFINITY` to always allow `lcs-linear`.
+   */
+  lcsLinearMaxCells?: number;
+  /**
    * Emit RFC 6902 `move` operations when a deterministic remove/add rewrite is available.
    * Defaults to `false` for backward compatibility.
    */

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -551,6 +551,22 @@ describe("diffJsonPatch", () => {
     expect(ops).toEqual([{ op: "replace", path: "/arr/1250", value: -1 }]);
   });
 
+  it("uses the linear guardrail without reusing lcsMaxCells", () => {
+    const baseArr = Array.from({ length: 2_500 }, (_, idx) => idx);
+    const nextArr = [...baseArr];
+    nextArr[1_250] = -1;
+
+    const base: JsonValue = { arr: baseArr };
+    const next: JsonValue = { arr: nextArr };
+    const ops = diffJsonPatch(base, next, {
+      arrayStrategy: "lcs-linear",
+      lcsMaxCells: 1,
+      lcsLinearMaxCells: 4,
+    });
+
+    expect(ops).toEqual([{ op: "replace", path: "/arr/1250", value: -1 }]);
+  });
+
   it("avoids atomic fallback for large unmatched windows with linear-space LCS", () => {
     const baseArr = Array.from({ length: 4_000 }, (_, idx) => idx);
     const nextArr = [...baseArr.slice(1), baseArr[0]!];
@@ -563,6 +579,20 @@ describe("diffJsonPatch", () => {
       { op: "remove", path: "/arr/0" },
       { op: "add", path: "/arr/3999", value: 0 },
     ]);
+  });
+
+  it("can fall back to atomic replacement for large unmatched windows with linear-space LCS", () => {
+    const baseArr = Array.from({ length: 4_000 }, (_, idx) => idx);
+    const nextArr = [...baseArr.slice(1), baseArr[0]!];
+
+    const base: JsonValue = { arr: baseArr };
+    const next: JsonValue = { arr: nextArr };
+    const ops = diffJsonPatch(base, next, {
+      arrayStrategy: "lcs-linear",
+      lcsLinearMaxCells: 1_000_000,
+    });
+
+    expect(ops).toEqual([{ op: "replace", path: "/arr", value: nextArr }]);
   });
 
   it("handles single unmatched base elements against large next arrays with linear-space LCS", () => {


### PR DESCRIPTION
## Summary
- add an opt-in `lcsLinearMaxCells` diff option for `arrayStrategy: "lcs-linear"`
- fall back to an atomic array `replace` when the trimmed unmatched window exceeds the configured cap
- document how `lcsLinearMaxCells` differs from the existing `lcsMaxCells` guardrail and add a changeset

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Closes #107
