### PR TITLE
Expose public version-vector inspection helpers

### DIFF
--- a/.changeset/calm-rabbits-repeat.md
+++ b/.changeset/calm-rabbits-repeat.md
@@ -1,0 +1,9 @@
+---
+"json-patch-to-crdt": minor
+---
+
+Expose public version-vector inspection helpers for sync and compaction flows.
+
+Add `observedVersionVector`, `mergeVersionVectors`, `intersectVersionVectors`,
+and `versionVectorCovers` to the main API surface, and document how to use them
+to derive sync checkpoints and causally-stable tombstone compaction checkpoints.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ if (versionVectorCovers(mergedCheckpoint, stableCheckpoint)) {
 Use `mergeVersionVectors(...)` for sync-style "what has this cluster observed?"
 bookkeeping. Use `intersectVersionVectors(...)` for tombstone compaction
 checkpoints, because compaction is only safe once every live peer covers the
-same delete dots.
+same delete dots. If you call `intersectVersionVectors(...)` with a single
+vector, it returns that vector unchanged.
 
 ## Runtime JSON Validation
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,38 @@ try {
 
 If you prefer non-throwing results, use `tryApplyPatch(...)` / `tryMergeState(...)`.
 
+## Version Vector Helpers
+
+`observedVersionVector(...)` lets you inspect the highest observed counter per
+actor from either a `Doc` or a `CrdtState`. Use `mergeVersionVectors(...)` to
+union peer observations, and `intersectVersionVectors(...)` when you need a
+causally-stable checkpoint that every replica has already seen.
+
+```ts
+import {
+  compactStateTombstones,
+  intersectVersionVectors,
+  mergeVersionVectors,
+  observedVersionVector,
+  versionVectorCovers,
+} from "json-patch-to-crdt";
+
+const seenByReplicaA = observedVersionVector(replicaA);
+const seenByReplicaB = observedVersionVector(replicaB);
+
+const mergedCheckpoint = mergeVersionVectors(seenByReplicaA, seenByReplicaB);
+const stableCheckpoint = intersectVersionVectors(seenByReplicaA, seenByReplicaB);
+
+if (versionVectorCovers(mergedCheckpoint, stableCheckpoint)) {
+  const compacted = compactStateTombstones(state, { stable: stableCheckpoint });
+}
+```
+
+Use `mergeVersionVectors(...)` for sync-style "what has this cluster observed?"
+bookkeeping. Use `intersectVersionVectors(...)` for tombstone compaction
+checkpoints, because compaction is only safe once every live peer covers the
+same delete dots.
+
 ## Runtime JSON Validation
 
 `createState`, `applyPatch`, `diffJsonPatch`, and `crdtToJsonPatch` accept a
@@ -196,6 +228,11 @@ Main exports most apps need:
 - `tryApplyPatch(state, patch, options?)`
 - `mergeState(local, remote, { actor })`
 - `tryMergeState(local, remote, options?)`
+- `observedVersionVector(stateOrDoc)`
+- `mergeVersionVectors(...vectors)`
+- `intersectVersionVectors(...vectors)`
+- `versionVectorCovers(observed, required)`
+- `compactStateTombstones(state, { stable })`
 - `toJson(stateOrDoc)`
 - `diffJsonPatch(baseJson, nextJson, options?)`
 - `serializeState(state)` / `deserializeState(payload)`

--- a/src/clock.ts
+++ b/src/clock.ts
@@ -1,5 +1,11 @@
 import type { ActorId, Clock, Dot, VersionVector } from "./types";
 
+import {
+  observeVersionVectorDot,
+  readVersionVectorCounter,
+  writeVersionVectorCounter,
+} from "./version-vector";
+
 export type ClockValidationErrorReason = "INVALID_ACTOR" | "INVALID_COUNTER";
 
 export class ClockValidationError extends TypeError {
@@ -10,24 +16,6 @@ export class ClockValidationError extends TypeError {
     this.name = "ClockValidationError";
     this.reason = reason;
   }
-}
-
-function readVvCounter(vv: VersionVector, actor: ActorId): number {
-  if (!Object.prototype.hasOwnProperty.call(vv, actor)) {
-    return 0;
-  }
-
-  const counter = vv[actor];
-  return typeof counter === "number" ? counter : 0;
-}
-
-function writeVvCounter(vv: VersionVector, actor: ActorId, counter: number): void {
-  Object.defineProperty(vv, actor, {
-    configurable: true,
-    enumerable: true,
-    value: counter,
-    writable: true,
-  });
 }
 
 /**
@@ -77,14 +65,12 @@ export function cloneClock(clock: Clock): Clock {
  * Useful when a server needs to mint dots for many actors.
  */
 export function nextDotForActor(vv: VersionVector, actor: ActorId): Dot {
-  const ctr = readVvCounter(vv, actor) + 1;
-  writeVvCounter(vv, actor, ctr);
+  const ctr = (readVersionVectorCounter(vv, actor) ?? 0) + 1;
+  writeVersionVectorCounter(vv, actor, ctr);
   return { actor, ctr };
 }
 
 /** Record an observed dot in a version vector. */
 export function observeDot(vv: VersionVector, dot: Dot): void {
-  if (readVvCounter(vv, dot.actor) < dot.ctr) {
-    writeVvCounter(vv, dot.actor, dot.ctr);
-  }
+  observeVersionVectorDot(vv, dot);
 }

--- a/src/dot.ts
+++ b/src/dot.ts
@@ -1,22 +1,6 @@
 import type { Dot, ElemId, VersionVector } from "./types";
 
-function readVvCounter(vv: VersionVector, actor: string): number | undefined {
-  if (!Object.prototype.hasOwnProperty.call(vv, actor)) {
-    return undefined;
-  }
-
-  const counter = vv[actor];
-  return typeof counter === "number" ? counter : undefined;
-}
-
-function writeVvCounter(vv: VersionVector, actor: string, counter: number): void {
-  Object.defineProperty(vv, actor, {
-    configurable: true,
-    enumerable: true,
-    value: counter,
-    writable: true,
-  });
-}
+import { mergeVersionVectors, readVersionVectorCounter } from "./version-vector";
 
 // total order for LWW (tie-break actor lexicographically)
 export function compareDot(a: Dot, b: Dot): number {
@@ -28,21 +12,11 @@ export function compareDot(a: Dot, b: Dot): number {
 }
 
 export function vvHasDot(vv: VersionVector, d: Dot): boolean {
-  return (readVvCounter(vv, d.actor) ?? 0) >= d.ctr;
+  return (readVersionVectorCounter(vv, d.actor) ?? 0) >= d.ctr;
 }
 
 export function vvMerge(a: VersionVector, b: VersionVector): VersionVector {
-  const out = Object.create(null) as VersionVector;
-
-  for (const [actor, ctr] of Object.entries(a)) {
-    writeVvCounter(out, actor, ctr);
-  }
-
-  for (const [actor, ctr] of Object.entries(b)) {
-    writeVvCounter(out, actor, Math.max(readVvCounter(out, actor) ?? 0, ctr));
-  }
-
-  return out;
+  return mergeVersionVectors(a, b);
 }
 
 export function dotToElemId(d: Dot): ElemId {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,12 @@ export {
 
 // Merge
 export { MergeError, mergeState, tryMergeState } from "./merge";
+export {
+  observedVersionVector,
+  mergeVersionVectors,
+  intersectVersionVectors,
+  versionVectorCovers,
+} from "./version-vector";
 
 // Tombstone compaction
 export { compactStateTombstones } from "./compact";

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -91,6 +91,12 @@ export { ROOT_KEY } from "./types";
 
 // Dot utilities.
 export { compareDot, vvHasDot, vvMerge, dotToElemId } from "./dot";
+export {
+  observedVersionVector,
+  mergeVersionVectors,
+  intersectVersionVectors,
+  versionVectorCovers,
+} from "./version-vector";
 
 // Low-level node constructors and operations.
 export { newObj, newSeq, newReg, lwwSet, objSet, objRemove, objCompactTombstones } from "./nodes";

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -20,6 +20,7 @@ import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth, toDepthApplyError } from "./depth";
 import { compareDot } from "./dot";
 import { stringifyJsonPointer } from "./patch";
+import { observedVersionVector } from "./version-vector";
 
 class SharedElementMetadataMismatchError extends Error {
   readonly path: string;
@@ -197,7 +198,7 @@ function findSeqLineageMismatch(a: Node, b: Node, path: string[]): string | null
 }
 
 function maxObservedCtrForActor(doc: Doc, actor: ActorId, a: CrdtState, b: CrdtState): number {
-  let best = maxCtrInNodeForActor(doc.root, actor);
+  let best = observedVersionVector(doc)[actor] ?? 0;
 
   if (a.clock.actor === actor && a.clock.ctr > best) {
     best = a.clock.ctr;
@@ -205,51 +206,6 @@ function maxObservedCtrForActor(doc: Doc, actor: ActorId, a: CrdtState, b: CrdtS
 
   if (b.clock.actor === actor && b.clock.ctr > best) {
     best = b.clock.ctr;
-  }
-
-  return best;
-}
-
-function maxCtrInNodeForActor(node: Node, actor: ActorId): number {
-  let best = 0;
-  const stack: Array<{ node: Node; depth: number }> = [{ node, depth: 0 }];
-
-  while (stack.length > 0) {
-    const frame = stack.pop()!;
-    assertTraversalDepth(frame.depth);
-
-    if (frame.node.kind === "lww") {
-      if (frame.node.dot.actor === actor && frame.node.dot.ctr > best) {
-        best = frame.node.dot.ctr;
-      }
-      continue;
-    }
-
-    if (frame.node.kind === "obj") {
-      for (const entry of frame.node.entries.values()) {
-        if (entry.dot.actor === actor && entry.dot.ctr > best) {
-          best = entry.dot.ctr;
-        }
-        stack.push({ node: entry.node, depth: frame.depth + 1 });
-      }
-
-      for (const tomb of frame.node.tombstone.values()) {
-        if (tomb.actor === actor && tomb.ctr > best) {
-          best = tomb.ctr;
-        }
-      }
-      continue;
-    }
-
-    for (const elem of frame.node.elems.values()) {
-      if (elem.insDot.actor === actor && elem.insDot.ctr > best) {
-        best = elem.insDot.ctr;
-      }
-      if (elem.delDot?.actor === actor && elem.delDot.ctr > best) {
-        best = elem.delDot.ctr;
-      }
-      stack.push({ node: elem.value, depth: frame.depth + 1 });
-    }
   }
 
   return best;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -18,6 +18,7 @@ import type {
 import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth } from "./depth";
 import { dotToElemId } from "./dot";
+import { observedVersionVector } from "./version-vector";
 
 const HEAD_ELEM_ID = "HEAD";
 const SERIALIZED_DOC_VERSION = 1 as const;
@@ -107,7 +108,7 @@ export function deserializeState(data: SerializedState): CrdtState {
   const actor = readActor(clockRaw.actor, "/clock/actor");
   const ctr = readCounter(clockRaw.ctr, "/clock/ctr");
   const doc = deserializeDoc(raw.doc as SerializedDoc);
-  const observedCtr = maxObservedCounterForActorInNode(doc.root, actor);
+  const observedCtr = observedVersionVector(doc)[actor] ?? 0;
   const clock = createClock(actor, Math.max(ctr, observedCtr));
   return { doc, clock };
 }
@@ -340,47 +341,6 @@ function assertAcyclicRgaPredecessors(elems: Map<string, RgaElem>, path: string)
       visitState.set(id, 2);
     }
   }
-}
-
-function maxObservedCounterForActorInNode(node: Node, actor: string): number {
-  if (node.kind === "lww") {
-    return node.dot.actor === actor ? node.dot.ctr : 0;
-  }
-
-  if (node.kind === "obj") {
-    let maxCtr = 0;
-
-    for (const entry of node.entries.values()) {
-      if (entry.dot.actor === actor) {
-        maxCtr = Math.max(maxCtr, entry.dot.ctr);
-      }
-
-      maxCtr = Math.max(maxCtr, maxObservedCounterForActorInNode(entry.node, actor));
-    }
-
-    for (const tombstoneDot of node.tombstone.values()) {
-      if (tombstoneDot.actor === actor) {
-        maxCtr = Math.max(maxCtr, tombstoneDot.ctr);
-      }
-    }
-
-    return maxCtr;
-  }
-
-  let maxCtr = 0;
-  for (const elem of node.elems.values()) {
-    if (elem.insDot.actor === actor) {
-      maxCtr = Math.max(maxCtr, elem.insDot.ctr);
-    }
-
-    if (elem.delDot?.actor === actor) {
-      maxCtr = Math.max(maxCtr, elem.delDot.ctr);
-    }
-
-    maxCtr = Math.max(maxCtr, maxObservedCounterForActorInNode(elem.value, actor));
-  }
-
-  return maxCtr;
 }
 
 function asRecord(value: unknown, path: string): Record<string, unknown> {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -92,7 +92,12 @@ export function serializeState(state: CrdtState): SerializedState {
   };
 }
 
-/** Reconstruct a full CRDT state from its serialized form, restoring the clock. */
+/**
+ * Reconstruct a full CRDT state from its serialized form, restoring the clock.
+ *
+ * May throw `TraversalDepthError` when the payload exceeds the maximum
+ * supported nesting depth.
+ */
 export function deserializeState(data: SerializedState): CrdtState {
   const raw = readSerializedStateEnvelope(data);
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -26,7 +26,7 @@ import type {
 } from "./types";
 
 import { createClock, cloneClock } from "./clock";
-import { TraversalDepthError, assertTraversalDepth, toDepthApplyError } from "./depth";
+import { TraversalDepthError, toDepthApplyError } from "./depth";
 import { applyIntentsToCrdt, cloneDoc, docFromJson } from "./doc";
 import {
   JsonValueValidationError,
@@ -44,6 +44,7 @@ import {
 } from "./patch";
 import { rgaIdAtIndex, rgaLength } from "./rga";
 import { ROOT_KEY } from "./types";
+import { observedVersionVector } from "./version-vector";
 
 /** Error thrown when a JSON Patch cannot be applied. Includes structured conflict metadata. */
 export class PatchError extends Error {
@@ -261,7 +262,7 @@ export function tryApplyPatchAsActor(
   patch: JsonPatchOp[],
   options: ApplyPatchAsActorOptions = {},
 ): TryApplyPatchAsActorResult {
-  const observedCtr = maxCtrInNodeForActor(doc.root, actor);
+  const observedCtr = observedVersionVector(doc)[actor] ?? 0;
   const start = Math.max(vv[actor] ?? 0, observedCtr);
 
   const baseState: CrdtState = {
@@ -1047,51 +1048,6 @@ function mergePointerPaths(basePointer: string, nestedPointer: string): string {
   }
 
   return `${basePointer}${nestedPointer}`;
-}
-
-function maxCtrInNodeForActor(node: Node, actor: ActorId): number {
-  let best = 0;
-  const stack: Array<{ node: Node; depth: number }> = [{ node, depth: 0 }];
-
-  while (stack.length > 0) {
-    const frame = stack.pop()!;
-    assertTraversalDepth(frame.depth);
-
-    if (frame.node.kind === "lww") {
-      if (frame.node.dot.actor === actor && frame.node.dot.ctr > best) {
-        best = frame.node.dot.ctr;
-      }
-      continue;
-    }
-
-    if (frame.node.kind === "obj") {
-      for (const entry of frame.node.entries.values()) {
-        if (entry.dot.actor === actor && entry.dot.ctr > best) {
-          best = entry.dot.ctr;
-        }
-        stack.push({ node: entry.node, depth: frame.depth + 1 });
-      }
-
-      for (const tomb of frame.node.tombstone.values()) {
-        if (tomb.actor === actor && tomb.ctr > best) {
-          best = tomb.ctr;
-        }
-      }
-      continue;
-    }
-
-    for (const elem of frame.node.elems.values()) {
-      if (elem.insDot.actor === actor && elem.insDot.ctr > best) {
-        best = elem.insDot.ctr;
-      }
-      if (elem.delDot?.actor === actor && elem.delDot.ctr > best) {
-        best = elem.delDot.ctr;
-      }
-      stack.push({ node: elem.value, depth: frame.depth + 1 });
-    }
-  }
-
-  return best;
 }
 
 function toApplyError(error: unknown): ApplyError {

--- a/src/version-vector.ts
+++ b/src/version-vector.ts
@@ -1,0 +1,125 @@
+import type { CrdtState, Doc, Dot, Node, VersionVector } from "./types";
+
+import { assertTraversalDepth } from "./depth";
+
+export function readVersionVectorCounter(vv: VersionVector, actor: string): number | undefined {
+  if (!Object.prototype.hasOwnProperty.call(vv, actor)) {
+    return undefined;
+  }
+
+  const counter = vv[actor];
+  return typeof counter === "number" ? counter : undefined;
+}
+
+export function writeVersionVectorCounter(vv: VersionVector, actor: string, counter: number): void {
+  Object.defineProperty(vv, actor, {
+    configurable: true,
+    enumerable: true,
+    value: counter,
+    writable: true,
+  });
+}
+
+export function observeVersionVectorDot(vv: VersionVector, dot: Dot): void {
+  if ((readVersionVectorCounter(vv, dot.actor) ?? 0) < dot.ctr) {
+    writeVersionVectorCounter(vv, dot.actor, dot.ctr);
+  }
+}
+
+/** Inspect a document or state and return the highest observed counter per actor. */
+export function observedVersionVector(target: Doc | CrdtState): VersionVector {
+  const doc = "doc" in target ? target.doc : target;
+  const vv = Object.create(null) as VersionVector;
+  const stack: Array<{ node: Node; depth: number }> = [{ node: doc.root, depth: 0 }];
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    assertTraversalDepth(frame.depth);
+
+    if (frame.node.kind === "lww") {
+      observeVersionVectorDot(vv, frame.node.dot);
+      continue;
+    }
+
+    if (frame.node.kind === "obj") {
+      for (const entry of frame.node.entries.values()) {
+        observeVersionVectorDot(vv, entry.dot);
+        stack.push({ node: entry.node, depth: frame.depth + 1 });
+      }
+
+      for (const tombstone of frame.node.tombstone.values()) {
+        observeVersionVectorDot(vv, tombstone);
+      }
+      continue;
+    }
+
+    for (const elem of frame.node.elems.values()) {
+      observeVersionVectorDot(vv, elem.insDot);
+      if (elem.delDot) {
+        observeVersionVectorDot(vv, elem.delDot);
+      }
+      stack.push({ node: elem.value, depth: frame.depth + 1 });
+    }
+  }
+
+  return vv;
+}
+
+/** Combine version vectors using per-actor maxima. */
+export function mergeVersionVectors(...vectors: readonly VersionVector[]): VersionVector {
+  const merged = Object.create(null) as VersionVector;
+
+  for (const vv of vectors) {
+    for (const actor of Object.keys(vv)) {
+      const counter = readVersionVectorCounter(vv, actor);
+      if (counter === undefined) {
+        continue;
+      }
+
+      writeVersionVectorCounter(
+        merged,
+        actor,
+        Math.max(readVersionVectorCounter(merged, actor) ?? 0, counter),
+      );
+    }
+  }
+
+  return merged;
+}
+
+/** Derive a causally-stable checkpoint by taking the per-actor minimum. */
+export function intersectVersionVectors(...vectors: readonly VersionVector[]): VersionVector {
+  if (vectors.length === 0) {
+    return Object.create(null) as VersionVector;
+  }
+
+  const actors = new Set<string>();
+  for (const vv of vectors) {
+    for (const actor of Object.keys(vv)) {
+      actors.add(actor);
+    }
+  }
+
+  const intersection = Object.create(null) as VersionVector;
+  for (const actor of actors) {
+    const counters = vectors.map((vv) => readVersionVectorCounter(vv, actor) ?? 0);
+    const counter = Math.min(...counters);
+    if (counter > 0) {
+      writeVersionVectorCounter(intersection, actor, counter);
+    }
+  }
+
+  return intersection;
+}
+
+/** Check whether one version vector has observed every counter in another. */
+export function versionVectorCovers(observed: VersionVector, required: VersionVector): boolean {
+  for (const actor of Object.keys(required)) {
+    const requiredCounter = readVersionVectorCounter(required, actor) ?? 0;
+    if ((readVersionVectorCounter(observed, actor) ?? 0) < requiredCounter) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/version-vector.ts
+++ b/src/version-vector.ts
@@ -26,10 +26,19 @@ export function observeVersionVectorDot(vv: VersionVector, dot: Dot): void {
   }
 }
 
-/** Inspect a document or state and return the highest observed counter per actor. */
+/**
+ * Inspect a document or state and return the highest observed counter per actor.
+ *
+ * When a `CrdtState` is provided, the returned vector is also seeded from the
+ * state's local clock so callers do not lose counters that have advanced ahead
+ * of the currently materialized document tree.
+ */
 export function observedVersionVector(target: Doc | CrdtState): VersionVector {
   const doc = "doc" in target ? target.doc : target;
   const vv = Object.create(null) as VersionVector;
+  if ("clock" in target) {
+    observeVersionVectorDot(vv, { actor: target.clock.actor, ctr: target.clock.ctr });
+  }
   const stack: Array<{ node: Node; depth: number }> = [{ node: doc.root, depth: 0 }];
 
   while (stack.length > 0) {
@@ -87,7 +96,13 @@ export function mergeVersionVectors(...vectors: readonly VersionVector[]): Versi
   return merged;
 }
 
-/** Derive a causally-stable checkpoint by taking the per-actor minimum. */
+/**
+ * Derive a causally-stable checkpoint by taking the per-actor minimum.
+ *
+ * When called with a single vector the result equals that vector. In practice,
+ * a meaningful shared-stability checkpoint usually needs acknowledgements from
+ * at least two peers or from an explicit quorum.
+ */
 export function intersectVersionVectors(...vectors: readonly VersionVector[]): VersionVector {
   if (vectors.length === 0) {
     return Object.create(null) as VersionVector;

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it } from "bun:test";
 import type { SerializedSyncRecord, SyncEnvelope, SyncJson, SyncRecord } from "./test-utils";
 
 import {
+  intersectVersionVectors as publicIntersectVersionVectors,
+  observedVersionVector as publicObservedVersionVector,
+} from "../src/index";
+import {
   applyIntentsToCrdt,
   applyPatch,
   applyPatchAsActor,
@@ -734,5 +738,24 @@ describe("tombstone compaction", () => {
     expect(compacted.stats.objectTombstonesRemoved).toBe(1);
     expect(objNode.tombstone.has("x")).toBeFalse();
     expect(materialize(removed.doc.root)).toEqual({ obj: {} });
+  });
+
+  it("derives stable compaction checkpoints from public version-vector helpers", () => {
+    const origin = createState({ obj: { x: 1 } }, { actor: "origin" });
+    const replicaA = forkState(origin, "A");
+    const replicaB = forkState(origin, "B");
+
+    const deletedOnA = applyPatch(replicaA, [{ op: "remove", path: "/obj/x" }]);
+    const mergedOnB = mergeState(replicaB, deletedOnA, { actor: "B" });
+    const stable = publicIntersectVersionVectors(
+      publicObservedVersionVector(deletedOnA),
+      publicObservedVersionVector(mergedOnB),
+    );
+
+    const compacted = compactStateTombstones(deletedOnA, { stable });
+    const objNode = (compacted.state.doc.root as any).entries.get("obj")?.node as any;
+
+    expect(objNode.tombstone.has("x")).toBeFalse();
+    expect(toJson(compacted.state)).toEqual({ obj: {} });
   });
 });

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -4,6 +4,9 @@ import { describe, expect, it } from "bun:test";
 import type { SerializedSyncRecord, SyncEnvelope, SyncJson, SyncRecord } from "./test-utils";
 
 import {
+  intersectVersionVectors,
+  mergeVersionVectors,
+  observedVersionVector,
   applyIntentsToCrdt,
   applyPatch,
   applyPatchAsActor,
@@ -64,6 +67,7 @@ import {
   tryMergeDoc,
   tryMergeState,
   toJson,
+  versionVectorCovers,
   vvHasDot,
   vvMerge,
   JsonValueValidationError,
@@ -141,6 +145,53 @@ describe("dots and version vectors", () => {
     expect(Object.prototype.hasOwnProperty.call(out, "__proto__")).toBeTrue();
     expect(out.__proto__).toBe(2);
     expect(Object.getPrototypeOf(out)).toBeNull();
+  });
+
+  it("observes version vectors across objects and arrays from docs and states", () => {
+    const state = createState(
+      {
+        obj: { nested: 1 },
+        list: ["a", { deep: true }],
+      },
+      { actor: "A" },
+    );
+
+    expect(observedVersionVector(state.doc)).toEqual({ A: state.clock.ctr });
+    expect(observedVersionVector(state)).toEqual({ A: state.clock.ctr });
+  });
+
+  it("observes object tombstone delete dots", () => {
+    const state = createState({ obj: { removed: 1 } }, { actor: "A" });
+    const removed = applyPatch(state, [{ op: "remove", path: "/obj/removed" }]);
+
+    expect(observedVersionVector(removed)).toEqual({ A: removed.clock.ctr });
+  });
+
+  it("observes sequence tombstone delete dots", () => {
+    const state = createState(["a"], { actor: "A" });
+    const removed = applyPatch(state, [{ op: "remove", path: "/0" }], {
+      semantics: "sequential",
+    });
+
+    expect(observedVersionVector(removed)).toEqual({ A: removed.clock.ctr });
+  });
+
+  it("supports public merge, intersection, and coverage checks for version vectors", () => {
+    const left = JSON.parse('{"A":3,"B":1,"__proto__":4}') as VersionVector;
+    const right: VersionVector = { A: 2, B: 5, C: 1 };
+
+    const merged = mergeVersionVectors(left, right) as Record<string, number>;
+    const intersection = intersectVersionVectors(left, right);
+
+    expect(merged.A).toBe(3);
+    expect(merged.B).toBe(5);
+    expect(merged.C).toBe(1);
+    expect(Object.prototype.hasOwnProperty.call(merged, "__proto__")).toBeTrue();
+    expect(merged.__proto__).toBe(4);
+    expect(Object.getPrototypeOf(merged)).toBeNull();
+    expect(intersection).toEqual({ A: 2, B: 1 });
+    expect(versionVectorCovers(merged, intersection)).toBeTrue();
+    expect(versionVectorCovers(intersection, merged)).toBeFalse();
   });
 });
 

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -167,6 +167,16 @@ describe("dots and version vectors", () => {
     expect(observedVersionVector(removed)).toEqual({ A: removed.clock.ctr });
   });
 
+  it("seeds observed state vectors from the local clock when it is ahead of the doc", () => {
+    const state = createState({ value: 1 }, { actor: "A" });
+    const ahead: CrdtState = {
+      doc: state.doc,
+      clock: createClock("A", state.clock.ctr + 3),
+    };
+
+    expect(observedVersionVector(ahead)).toEqual({ A: ahead.clock.ctr });
+  });
+
   it("observes sequence tombstone delete dots", () => {
     const state = createState(["a"], { actor: "A" });
     const removed = applyPatch(state, [{ op: "remove", path: "/0" }], {


### PR DESCRIPTION
## Summary
- add public version-vector helpers for observing, merging, intersecting, and coverage checks
- reuse the shared document traversal in actor clock recovery paths for patch application, merge, and state deserialization
- document merge/compaction checkpoint workflows and add a changeset for release notes

## Changes Made
- added `observedVersionVector`, `mergeVersionVectors`, `intersectVersionVectors`, and `versionVectorCovers` to the main API surface and internals entry point
- introduced a shared `src/version-vector.ts` module and routed existing version-vector helpers through it
- added acceptance coverage for objects, arrays, object tombstones, and sequence tombstones
- added a public helper driven compaction workflow test and README guidance for sync and tombstone compaction usage

## Verification
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #108
