### PR TITLE
fix: reduce object diff move/copy rewrite overhead

### DIFF
--- a/.changeset/twenty-frogs-jump.md
+++ b/.changeset/twenty-frogs-jump.md
@@ -1,0 +1,10 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Reduce object move/copy rewrite overhead in `diffJsonPatch` by memoizing
+stable structural fingerprints and bucketing deterministic copy sources.
+
+Add regression coverage for memoized structural keys and wide nested
+object rename/duplicate rewrites, plus a dedicated nested rewrite
+microbenchmark in `bench:object-diff`.

--- a/bench/object-diff.microbench.ts
+++ b/bench/object-diff.microbench.ts
@@ -392,7 +392,7 @@ function runNestedRewriteScenario(width: number, runs: number): void {
   const baselineOps = diffJsonPatch(base, next);
   const rewriteOps = diffJsonPatch(base, next, rewriteOptions);
 
-  if (!rewriteOps.every((op) => op.op === "move" || op.op === "copy")) {
+  if (rewriteOps.length > 0 && !rewriteOps.every((op) => op.op === "move" || op.op === "copy")) {
     throw new Error("nested rewrite benchmark expected move/copy-only output");
   }
 

--- a/bench/object-diff.microbench.ts
+++ b/bench/object-diff.microbench.ts
@@ -90,8 +90,70 @@ function buildNextWideObject(
   return next;
 }
 
+function buildNestedValue(index: number): JsonValue {
+  return {
+    meta: {
+      id: index,
+      label: `item-${index}`,
+      tags: [`tag-${index % 7}`, `group-${index % 5}`],
+    },
+    payload: {
+      active: index % 2 === 0,
+      score: index * 10,
+      trail: [index, index + 1, index + 2],
+    },
+  };
+}
+
+function buildWideNestedObject(width: number): Record<string, JsonValue> {
+  const out: Record<string, JsonValue> = {};
+
+  for (let i = 0; i < width; i++) {
+    out[formatKey(i)] = buildNestedValue(i);
+  }
+
+  return out;
+}
+
+function buildNextWideNestedRewriteObject(
+  base: Record<string, JsonValue>,
+  width: number,
+): Record<string, JsonValue> {
+  const renameIndexes = uniqueIndexes(width, [1, Math.floor(width / 5), Math.floor(width / 2)]);
+  const duplicateIndexes = uniqueIndexes(width, [
+    2,
+    Math.floor(width / 4),
+    Math.floor((width * 4) / 5),
+  ]).filter((index) => !renameIndexes.includes(index));
+  const next: Record<string, JsonValue> = {};
+
+  for (let i = 0; i < width; i++) {
+    const sourceKey = formatKey(i);
+    const targetKey = renameIndexes.includes(i) ? formatRenamedKey(i) : sourceKey;
+    next[targetKey] = base[sourceKey]!;
+  }
+
+  for (const index of duplicateIndexes) {
+    next[formatDuplicateKey(index)] = base[formatKey(index)]!;
+  }
+
+  return next;
+}
+
 function formatKey(index: number): string {
   return `k${String(index).padStart(5, "0")}`;
+}
+
+function formatRenamedKey(index: number): string {
+  return `renamed-${String(index).padStart(5, "0")}`;
+}
+
+function formatDuplicateKey(index: number): string {
+  return `duplicate-${String(index).padStart(5, "0")}`;
+}
+
+function uniqueIndexes(width: number, indexes: readonly number[]): number[] {
+  return [...new Set(indexes.filter((index) => index >= 0 && index < width))].sort((a, b) => a - b);
 }
 
 function legacyDiffJsonPatch(base: JsonValue, next: JsonValue): JsonPatchOp[] {
@@ -322,7 +384,43 @@ function runScenario(width: number, runs: number): void {
   console.log(`avg heap delta reduction: ${format(heapDeltaReduction)} MB`);
 }
 
+function runNestedRewriteScenario(width: number, runs: number): void {
+  const base = buildWideNestedObject(width);
+  const next = buildNextWideNestedRewriteObject(base, width);
+  const rewriteOptions = { emitMoves: true, emitCopies: true } as const;
+
+  const baselineOps = diffJsonPatch(base, next);
+  const rewriteOps = diffJsonPatch(base, next, rewriteOptions);
+
+  if (!rewriteOps.every((op) => op.op === "move" || op.op === "copy")) {
+    throw new Error("nested rewrite benchmark expected move/copy-only output");
+  }
+
+  const baselineStats = measure("nested-object-diff", runs, () => {
+    diffJsonPatch(base, next);
+  });
+  const rewriteStats = measure("nested-object-diff+rewrites", runs, () => {
+    diffJsonPatch(base, next, rewriteOptions);
+  });
+  const overhead = rewriteStats.avgMs / baselineStats.avgMs;
+
+  console.log("");
+  console.log("Object diff microbenchmark (nested rename/duplicate rewrites)");
+  console.log(`width=${width} runs=${runs}`);
+  console.log(`baseline op count=${baselineOps.length} rewrite op count=${rewriteOps.length}`);
+  console.log(
+    [
+      "name                       avg(ms)  p50(ms)  min(ms)  max(ms)  avgHeapDelta(MB)",
+      `${baselineStats.name.padEnd(26)} ${format(baselineStats.avgMs).padStart(7)} ${format(baselineStats.p50Ms).padStart(8)} ${format(baselineStats.minMs).padStart(8)} ${format(baselineStats.maxMs).padStart(8)} ${format(baselineStats.avgHeapDeltaMb).padStart(16)}`,
+      `${rewriteStats.name.padEnd(26)} ${format(rewriteStats.avgMs).padStart(7)} ${format(rewriteStats.p50Ms).padStart(8)} ${format(rewriteStats.minMs).padStart(8)} ${format(rewriteStats.maxMs).padStart(8)} ${format(rewriteStats.avgHeapDeltaMb).padStart(16)}`,
+    ].join("\n"),
+  );
+  console.log(`rewrite overhead(avg): ${format(overhead)}x`);
+}
+
 const width = parsePositiveIntEnv("BENCH_OBJECT_DIFF_WIDTH", 50_000);
 const runs = parsePositiveIntEnv("BENCH_OBJECT_DIFF_RUNS", 6);
+const rewriteWidth = parsePositiveIntEnv("BENCH_OBJECT_REWRITE_WIDTH", 5_000);
 
 runScenario(width, runs);
+runNestedRewriteScenario(rewriteWidth, runs);

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -38,6 +38,7 @@ export {
   compileJsonPatchToIntent,
   PatchCompileError,
   jsonEquals,
+  stableJsonValueKey,
 } from "./patch";
 
 // Node-level materialization helper.

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -582,13 +582,13 @@ function insertObjectSourceBucket(
   structuralKeyCache: WeakMap<object, string>,
 ): void {
   const bucketKey = stableJsonValueKey(value, structuralKeyCache);
-  const bucket = buckets.get(bucketKey);
-  if (bucket) {
-    insertSortedKey(bucket, key);
-    return;
+  let bucket = buckets.get(bucketKey);
+  if (!bucket) {
+    bucket = [];
+    buckets.set(bucketKey, bucket);
   }
 
-  buckets.set(bucketKey, [key]);
+  insertSortedKey(bucket, key);
 }
 
 function findObjectCopySource(
@@ -1173,6 +1173,7 @@ function finalizeArrayOps(
   return out;
 }
 
+/** @internal Stable structural fingerprint used for deterministic diff rewrites. */
 export function stableJsonValueKey(
   value: JsonValue,
   structuralKeyCache?: WeakMap<object, string>,

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -63,11 +63,13 @@ interface StableJsonValueFrame {
 
 interface StableJsonArrayFrame {
   readonly kind: "array";
+  readonly value: readonly JsonValue[];
   readonly startIndex: number;
 }
 
 interface StableJsonObjectFrame {
   readonly kind: "object";
+  readonly value: Record<string, JsonValue>;
   readonly keys: readonly string[];
   readonly startIndex: number;
 }
@@ -491,22 +493,17 @@ function emitObjectStructuralOps(
     return;
   }
 
+  const structuralKeyCache = new WeakMap<object, string>();
   const matchedMoveSources = new Set<string>();
   const moveTargets = new Map<string, string>();
   if (options.emitMoves) {
     const moveSourceBuckets = new Map<string, string[]>();
     for (const baseKey of baseOnlyKeys) {
-      const bucketKey = stableJsonValueKey(base[baseKey]!);
-      const bucket = moveSourceBuckets.get(bucketKey);
-      if (bucket) {
-        bucket.push(baseKey);
-      } else {
-        moveSourceBuckets.set(bucketKey, [baseKey]);
-      }
+      insertObjectSourceBucket(moveSourceBuckets, baseKey, base[baseKey]!, structuralKeyCache);
     }
 
     for (const nextKey of nextOnlyKeys) {
-      const bucket = moveSourceBuckets.get(stableJsonValueKey(next[nextKey]!));
+      const bucket = moveSourceBuckets.get(stableJsonValueKey(next[nextKey]!, structuralKeyCache));
       if (!bucket) {
         continue;
       }
@@ -519,15 +516,13 @@ function emitObjectStructuralOps(
     }
   }
 
-  const availableSources = new Map<string, JsonValue>();
-  const availableSourceKeys: string[] = [];
+  const copySourceBuckets = new Map<string, string[]>();
   for (const key of sharedKeys) {
     if (!jsonEquals(base[key]!, next[key]!)) {
       continue;
     }
 
-    availableSources.set(key, base[key]!);
-    availableSourceKeys.push(key);
+    insertObjectSourceBucket(copySourceBuckets, key, base[key]!, structuralKeyCache);
   }
 
   for (const nextKey of nextOnlyKeys) {
@@ -541,24 +536,22 @@ function emitObjectStructuralOps(
       const fromPath = stringifyJsonPointer(path);
       path.pop();
       ops.push({ op: "move", from: fromPath, path: targetPath });
-      availableSources.set(nextKey, next[nextKey]!);
-      insertSortedKey(availableSourceKeys, nextKey);
+      insertObjectSourceBucket(copySourceBuckets, nextKey, next[nextKey]!, structuralKeyCache);
       continue;
     }
 
     if (options.emitCopies) {
       const copySource = findObjectCopySource(
-        availableSourceKeys,
-        availableSources,
+        copySourceBuckets,
         next[nextKey]!,
+        structuralKeyCache,
       );
       if (copySource !== undefined) {
         path.push(copySource);
         const fromPath = stringifyJsonPointer(path);
         path.pop();
         ops.push({ op: "copy", from: fromPath, path: targetPath });
-        availableSources.set(nextKey, next[nextKey]!);
-        insertSortedKey(availableSourceKeys, nextKey);
+        insertObjectSourceBucket(copySourceBuckets, nextKey, next[nextKey]!, structuralKeyCache);
         continue;
       }
     }
@@ -568,8 +561,7 @@ function emitObjectStructuralOps(
       path: targetPath,
       value: next[nextKey]!,
     });
-    availableSources.set(nextKey, next[nextKey]!);
-    insertSortedKey(availableSourceKeys, nextKey);
+    insertObjectSourceBucket(copySourceBuckets, nextKey, next[nextKey]!, structuralKeyCache);
   }
 
   for (const baseKey of baseOnlyKeys) {
@@ -583,18 +575,28 @@ function emitObjectStructuralOps(
   }
 }
 
-function findObjectCopySource(
-  sortedKeys: readonly string[],
-  availableSources: ReadonlyMap<string, JsonValue>,
-  target: JsonValue,
-): string | undefined {
-  for (const key of sortedKeys) {
-    if (jsonEquals(availableSources.get(key)!, target)) {
-      return key;
-    }
+function insertObjectSourceBucket(
+  buckets: Map<string, string[]>,
+  key: string,
+  value: JsonValue,
+  structuralKeyCache: WeakMap<object, string>,
+): void {
+  const bucketKey = stableJsonValueKey(value, structuralKeyCache);
+  const bucket = buckets.get(bucketKey);
+  if (bucket) {
+    insertSortedKey(bucket, key);
+    return;
   }
 
-  return undefined;
+  buckets.set(bucketKey, [key]);
+}
+
+function findObjectCopySource(
+  copySourceBuckets: ReadonlyMap<string, readonly string[]>,
+  target: JsonValue,
+  structuralKeyCache: WeakMap<object, string>,
+): string | undefined {
+  return copySourceBuckets.get(stableJsonValueKey(target, structuralKeyCache))?.[0];
 }
 
 function insertSortedKey(keys: string[], key: string): void {
@@ -1171,7 +1173,17 @@ function finalizeArrayOps(
   return out;
 }
 
-function stableJsonValueKey(value: JsonValue): string {
+export function stableJsonValueKey(
+  value: JsonValue,
+  structuralKeyCache?: WeakMap<object, string>,
+): string {
+  if (value !== null && typeof value === "object") {
+    const cachedValue = structuralKeyCache?.get(value);
+    if (cachedValue !== undefined) {
+      return cachedValue;
+    }
+  }
+
   const stack: StableJsonKeyFrame[] = [{ kind: "value", value, depth: 0 }];
   const results: string[] = [];
 
@@ -1180,17 +1192,19 @@ function stableJsonValueKey(value: JsonValue): string {
 
     if (frame.kind === "array") {
       const childParts = results.splice(frame.startIndex);
-      results.push(`[${childParts.join(",")}]`);
+      const stableKey = `[${childParts.join(",")}]`;
+      structuralKeyCache?.set(frame.value, stableKey);
+      results.push(stableKey);
       continue;
     }
 
     if (frame.kind === "object") {
       const childParts = results.splice(frame.startIndex);
-      results.push(
-        `{${frame.keys
-          .map((key, index) => `${JSON.stringify(key)}:${childParts[index]!}`)
-          .join(",")}}`,
-      );
+      const stableKey = `{${frame.keys
+        .map((key, index) => `${JSON.stringify(key)}:${childParts[index]!}`)
+        .join(",")}}`;
+      structuralKeyCache?.set(frame.value, stableKey);
+      results.push(stableKey);
       continue;
     }
 
@@ -1201,9 +1215,15 @@ function stableJsonValueKey(value: JsonValue): string {
       continue;
     }
 
+    const cachedValue = structuralKeyCache?.get(frame.value);
+    if (cachedValue !== undefined) {
+      results.push(cachedValue);
+      continue;
+    }
+
     if (Array.isArray(frame.value)) {
       const startIndex = results.length;
-      stack.push({ kind: "array", startIndex });
+      stack.push({ kind: "array", value: frame.value, startIndex });
       for (let index = frame.value.length - 1; index >= 0; index--) {
         stack.push({
           kind: "value",
@@ -1216,7 +1236,7 @@ function stableJsonValueKey(value: JsonValue): string {
 
     const keys = Object.keys(frame.value).sort();
     const startIndex = results.length;
-    stack.push({ kind: "object", keys, startIndex });
+    stack.push({ kind: "object", value: frame.value, keys, startIndex });
     for (let index = keys.length - 1; index >= 0; index--) {
       const key = keys[index]!;
       stack.push({

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -722,6 +722,40 @@ describe("diffJsonPatch", () => {
     expect(applyJsonPatch(base, ops)).toEqual(next);
   });
 
+  it("keeps wide nested object move and copy rewrites deterministic", () => {
+    const buildNestedValue = (index: number): JsonValue => ({
+      meta: {
+        id: index,
+        tags: [`tag-${index}`, `group-${index % 5}`],
+      },
+      payload: {
+        active: index % 2 === 0,
+        score: index * 10,
+      },
+    });
+
+    const baseEntries = Array.from({ length: 24 }, (_, index) => [
+      `k${String(index).padStart(2, "0")}`,
+      buildNestedValue(index),
+    ]);
+    const base: JsonValue = Object.fromEntries(baseEntries);
+    const nextEntries = baseEntries.map(([key, value]) => [key, value]);
+    nextEntries[5] = ["renamed-05", nextEntries[5]![1]];
+    nextEntries.push(["duplicate-22", nextEntries[22]![1]]);
+    const next: JsonValue = Object.fromEntries(nextEntries);
+
+    const ops = diffJsonPatch(base, next, {
+      emitMoves: true,
+      emitCopies: true,
+    });
+
+    expect(ops).toEqual([
+      { op: "copy", from: "/k22", path: "/duplicate-22" },
+      { op: "move", from: "/k05", path: "/renamed-05" },
+    ]);
+    expect(applyJsonPatch(base, ops)).toEqual(next);
+  });
+
   it("prefers deterministic earliest copy sources for duplicates", () => {
     const base: JsonValue = { arr: [1, 1] };
     const next: JsonValue = { arr: [1, 1, 1] };

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -18,8 +18,38 @@ import {
   docFromJson,
 } from "../src/internals";
 import { setMaterializeObserverForTests } from "../src/materialize";
+import { stableJsonValueKey } from "../src/patch";
 
 describe("performance regressions", () => {
+  it("memoizes structural fingerprints for repeated nested nodes", () => {
+    const hits = { count: 0 };
+    const leaf = {};
+    Object.defineProperty(leaf, "label", {
+      enumerable: true,
+      get: () => {
+        hits.count += 1;
+        return "deep";
+      },
+    });
+    const value = {};
+    Object.defineProperty(value, "child", {
+      enumerable: true,
+      get: () => {
+        hits.count += 1;
+        return leaf;
+      },
+    });
+
+    const cache = new WeakMap<object, string>();
+    const firstKey = stableJsonValueKey(value as JsonValue, cache);
+    const hitsAfterFirstPass = hits.count;
+    const secondKey = stableJsonValueKey(value as JsonValue, cache);
+
+    expect(firstKey).toBe(secondKey);
+    expect(hitsAfterFirstPass).toBeGreaterThan(0);
+    expect(hits.count).toBe(hitsAfterFirstPass);
+  });
+
   it("diffs large arrays with a narrow changed window without full-array replace", () => {
     const baseArr = Array.from({ length: 1_500 }, (_, idx) => idx);
     const nextArr = [...baseArr];

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -16,9 +16,9 @@ import {
   cloneDoc,
   compileJsonPatchToIntent,
   docFromJson,
+  stableJsonValueKey,
 } from "../src/internals";
 import { setMaterializeObserverForTests } from "../src/materialize";
-import { stableJsonValueKey } from "../src/patch";
 
 describe("performance regressions", () => {
   it("memoizes structural fingerprints for repeated nested nodes", () => {


### PR DESCRIPTION
## Summary
- memoize stable structural fingerprints during object move/copy rewrite matching in `diffJsonPatch`
- bucket deterministic object copy sources by structural fingerprint so copy detection does not repeatedly rescan sorted keys
- add regression coverage, a nested wide-object rewrite benchmark, and the required changeset for release notes

## Implementation details
- thread a shared `WeakMap<object, string>` through object move/copy rewriting so repeated nested nodes reuse their structural fingerprint
- replace linear object copy-source scanning with per-fingerprint sorted buckets while preserving the existing deterministic earliest-source selection rules
- add targeted tests for memoized structural-key reuse and wide nested rename/duplicate rewrite ordering

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`
- `BENCH_OBJECT_DIFF_WIDTH=1000 BENCH_OBJECT_REWRITE_WIDTH=400 BENCH_OBJECT_DIFF_RUNS=2 bun run bench/object-diff.microbench.ts`

Fixes #109
