### PR TITLE
fix: speed up duplicate-heavy array move/copy rewrites

### DIFF
--- a/.changeset/itchy-oranges-drift.md
+++ b/.changeset/itchy-oranges-drift.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Speed up duplicate-heavy array move/copy rewrite passes by indexing shadow-array rewrite candidates with stable structural keys instead of repeatedly rescanning the evolving array during finalize-time copy and move detection. Add regression coverage for the duplicate-heavy copy path and extend the array diff microbenchmark with duplicate-heavy append, insert, and reorder scenarios using `emitCopies` and `emitMoves`.

--- a/bench/array-diff.microbench.ts
+++ b/bench/array-diff.microbench.ts
@@ -94,6 +94,84 @@ function buildRotateLeftArrayEdit(length: number): { base: JsonValue; next: Json
   };
 }
 
+function buildDuplicateHeavyValue(id: number): JsonValue {
+  return {
+    kind: "dup",
+    id,
+    payload: {
+      bucket: id % 5,
+      flags: [id % 2 === 0, id % 3 === 0],
+    },
+  };
+}
+
+function buildDuplicateHeavyAppendEdit(length: number): { base: JsonValue; next: JsonValue } {
+  const stablePrefixLength = Math.max(length - 2, 1);
+  const stablePrefix = Array.from({ length: stablePrefixLength }, (_, idx) => ({
+    kind: "stable",
+    idx,
+  }));
+  const duplicateValues = Array.from({ length: 6 }, () => buildDuplicateHeavyValue(9_999));
+
+  return {
+    base: { arr: [...stablePrefix, duplicateValues[0]!, duplicateValues[1]!] },
+    next: { arr: [...stablePrefix, ...duplicateValues] },
+  };
+}
+
+function buildDuplicateHeavyInsertEdit(length: number): { base: JsonValue; next: JsonValue } {
+  const stablePrefixLength = Math.max(length - 6, 1);
+  const stablePrefix = Array.from({ length: stablePrefixLength }, (_, idx) => ({
+    kind: "stable",
+    idx,
+  }));
+  const stableSuffix = Array.from({ length: 4 }, (_, idx) => ({
+    kind: "suffix",
+    idx,
+  }));
+  const duplicateValues = Array.from({ length: 4 }, () => buildDuplicateHeavyValue(7_777));
+
+  return {
+    base: {
+      arr: [...stablePrefix, duplicateValues[0]!, duplicateValues[1]!, ...stableSuffix],
+    },
+    next: {
+      arr: [...stablePrefix, ...duplicateValues, ...stableSuffix],
+    },
+  };
+}
+
+function buildDuplicateHeavyReorderEdit(length: number): { base: JsonValue; next: JsonValue } {
+  const stablePrefixLength = Math.max(length - 5, 1);
+  const stablePrefix = Array.from({ length: stablePrefixLength }, (_, idx) => ({
+    kind: "stable",
+    idx,
+  }));
+
+  return {
+    base: {
+      arr: [
+        ...stablePrefix,
+        buildDuplicateHeavyValue(101),
+        buildDuplicateHeavyValue(202),
+        buildDuplicateHeavyValue(101),
+        buildDuplicateHeavyValue(202),
+        buildDuplicateHeavyValue(303),
+      ],
+    },
+    next: {
+      arr: [
+        buildDuplicateHeavyValue(202),
+        ...stablePrefix,
+        buildDuplicateHeavyValue(101),
+        buildDuplicateHeavyValue(202),
+        buildDuplicateHeavyValue(101),
+        buildDuplicateHeavyValue(303),
+      ],
+    },
+  };
+}
+
 function runDiff(base: JsonValue, next: JsonValue, options: DiffOptions): JsonPatchOp[] {
   return diffJsonPatch(base, next, options);
 }
@@ -167,10 +245,57 @@ function runGuardrailScenario(length: number): void {
   );
 }
 
+function runDuplicateHeavyRewriteScenarios(length: number, runs: number): void {
+  const scenarios = [
+    {
+      name: "dup-copy-append",
+      ...buildDuplicateHeavyAppendEdit(length),
+      options: { arrayStrategy: "lcs", emitCopies: true } satisfies DiffOptions,
+    },
+    {
+      name: "dup-copy-insert",
+      ...buildDuplicateHeavyInsertEdit(length),
+      options: { arrayStrategy: "lcs", emitCopies: true } satisfies DiffOptions,
+    },
+    {
+      name: "dup-move-reorder",
+      ...buildDuplicateHeavyReorderEdit(length),
+      options: { arrayStrategy: "lcs", emitMoves: true, emitCopies: true } satisfies DiffOptions,
+    },
+  ];
+
+  const stats: BenchmarkStats[] = [];
+
+  for (const scenario of scenarios) {
+    const firstPatch = runDiff(scenario.base, scenario.next, scenario.options);
+    const secondPatch = runDiff(scenario.base, scenario.next, scenario.options);
+    if (JSON.stringify(firstPatch) !== JSON.stringify(secondPatch)) {
+      throw new Error(`${scenario.name} produced non-deterministic rewrite output`);
+    }
+
+    stats.push(
+      measure(scenario.name, runs, () => runDiff(scenario.base, scenario.next, scenario.options)),
+    );
+  }
+
+  console.log("Duplicate-heavy rewrite microbenchmark (emitMoves/emitCopies)");
+  console.log(`length=${length} runs=${runs}`);
+  logTable(stats);
+  for (const scenario of scenarios) {
+    const patch = runDiff(scenario.base, scenario.next, scenario.options);
+    console.log(
+      `${scenario.name} ops=${patch.length} first=${summarizePatchOp(patch[0])} last=${summarizePatchOp(patch[patch.length - 1])}`,
+    );
+  }
+}
+
 const mediumLength = parsePositiveIntEnv("BENCH_ARRAY_DIFF_MEDIUM_SIZE", 1_800);
 const largeLength = parsePositiveIntEnv("BENCH_ARRAY_DIFF_LARGE_SIZE", 4_000);
+const duplicateLength = parsePositiveIntEnv("BENCH_ARRAY_DIFF_DUPLICATE_SIZE", 1_500);
 const runs = parsePositiveIntEnv("BENCH_ARRAY_DIFF_RUNS", 12);
 
 runMatrixVsLinearScenario(mediumLength, runs);
 console.log("");
 runGuardrailScenario(largeLength);
+console.log("");
+runDuplicateHeavyRewriteScenarios(duplicateLength, runs);

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -82,6 +82,18 @@ interface ObjectKeyGroups {
   readonly nextOnlyKeys: string[];
 }
 
+interface ArrayRewriteEntry {
+  value: JsonValue;
+  key: string;
+  currentIndex: number;
+}
+
+interface ArrayRewriteState {
+  readonly entries: ArrayRewriteEntry[];
+  readonly buckets: Map<string, ArrayRewriteEntry[]>;
+  readonly structuralKeyCache: WeakMap<object, string>;
+}
+
 /** Structured compile error used to map patch validation failures to typed reasons. */
 export class PatchCompileError extends Error {
   readonly reason: PatchErrorReason;
@@ -1077,17 +1089,17 @@ function finalizeArrayOps(
   }
 
   const out: JsonPatchOp[] = [];
-  // Keep prefix/suffix elements in the shadow array so copy detection can
+  // Keep prefix/suffix elements in the shadow state so copy detection can
   // reference stable sources outside the trimmed diff window.
-  const working = base.slice();
+  const working = createArrayRewriteState(base);
 
   for (let i = 0; i < ops.length; i++) {
     const op = ops[i]!;
     const next = ops[i + 1];
 
     if (op.op === "remove" && next && next.op === "add") {
-      const removedValue = working[getArrayOpIndex(op.path, arrayPath)]!;
-      const valuesMatch = jsonEquals(removedValue, next.value);
+      const removedEntry = working.entries[getArrayOpIndex(op.path, arrayPath)]!;
+      const valuesMatch = removedEntry.key === getArrayRewriteValueKey(working, next.value);
 
       if (op.path === next.path) {
         const replaceOp: JsonPatchOp = { op: "replace", path: op.path, value: next.value };
@@ -1125,8 +1137,8 @@ function finalizeArrayOps(
       const sourceIndex = removeIndex - (targetIndex <= removeIndex ? 1 : 0);
       const matchesPendingRemove =
         sourceIndex >= 0 &&
-        sourceIndex < working.length &&
-        jsonEquals(working[sourceIndex]!, op.value);
+        sourceIndex < working.entries.length &&
+        working.entries[sourceIndex]!.key === getArrayRewriteValueKey(working, op.value);
 
       if (options.emitMoves && matchesPendingRemove) {
         const moveOp: JsonPatchOp = {
@@ -1270,14 +1282,79 @@ function compactArrayOps(ops: JsonPatchOp[]): JsonPatchOp[] {
   return out;
 }
 
-function findArrayCopySourceIndex(working: JsonValue[], value: JsonValue): number {
-  for (let index = 0; index < working.length; index++) {
-    if (jsonEquals(working[index]!, value)) {
-      return index;
+function createArrayRewriteState(base: JsonValue[]): ArrayRewriteState {
+  const structuralKeyCache = new WeakMap<object, string>();
+  const buckets = new Map<string, ArrayRewriteEntry[]>();
+  const entries = base.map((value, currentIndex) => {
+    const entry: ArrayRewriteEntry = {
+      value,
+      key: stableJsonValueKey(value, structuralKeyCache),
+      currentIndex,
+    };
+    insertArrayRewriteBucketEntry(buckets, entry);
+    return entry;
+  });
+
+  return { entries, buckets, structuralKeyCache };
+}
+
+function getArrayRewriteValueKey(state: ArrayRewriteState, value: JsonValue): string {
+  return stableJsonValueKey(value, state.structuralKeyCache);
+}
+
+function findArrayCopySourceIndex(state: ArrayRewriteState, value: JsonValue): number {
+  return state.buckets.get(getArrayRewriteValueKey(state, value))?.[0]?.currentIndex ?? -1;
+}
+
+function insertArrayRewriteBucketEntry(
+  buckets: Map<string, ArrayRewriteEntry[]>,
+  entry: ArrayRewriteEntry,
+): void {
+  let bucket = buckets.get(entry.key);
+  if (!bucket) {
+    bucket = [];
+    buckets.set(entry.key, bucket);
+  }
+
+  let low = 0;
+  let high = bucket.length;
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (bucket[mid]!.currentIndex < entry.currentIndex) {
+      low = mid + 1;
+    } else {
+      high = mid;
     }
   }
 
-  return -1;
+  bucket.splice(low, 0, entry);
+}
+
+function removeArrayRewriteBucketEntry(
+  buckets: Map<string, ArrayRewriteEntry[]>,
+  entry: ArrayRewriteEntry,
+): void {
+  const bucket = buckets.get(entry.key);
+  if (!bucket) {
+    return;
+  }
+
+  const bucketIndex = bucket.indexOf(entry);
+  if (bucketIndex === -1) {
+    return;
+  }
+
+  bucket.splice(bucketIndex, 1);
+  if (bucket.length === 0) {
+    buckets.delete(entry.key);
+  }
+}
+
+function reindexArrayRewriteEntries(entries: ArrayRewriteEntry[], startIndex: number): void {
+  for (let index = startIndex; index < entries.length; index++) {
+    entries[index]!.currentIndex = index;
+  }
 }
 
 function getArrayOpIndex(ptr: string, arrayPath: string[]): number {
@@ -1301,48 +1378,84 @@ function getArrayOpIndex(ptr: string, arrayPath: string[]): number {
 }
 
 function applyArrayOptimizationOp(
-  working: JsonValue[],
+  working: ArrayRewriteState,
   op: JsonPatchOp,
   arrayPath: string[],
 ): void {
   if (op.op === "add") {
-    working.splice(getArrayOpIndex(op.path, arrayPath), 0, structuredClone(op.value));
+    const index = getArrayOpIndex(op.path, arrayPath);
+    const value = structuredClone(op.value);
+    const entry: ArrayRewriteEntry = {
+      value,
+      key: getArrayRewriteValueKey(working, op.value),
+      currentIndex: index,
+    };
+    working.entries.splice(index, 0, entry);
+    insertArrayRewriteBucketEntry(working.buckets, entry);
+    reindexArrayRewriteEntries(working.entries, index + 1);
     return;
   }
 
   if (op.op === "remove") {
-    working.splice(getArrayOpIndex(op.path, arrayPath), 1);
+    const index = getArrayOpIndex(op.path, arrayPath);
+    const [removedEntry] = working.entries.splice(index, 1);
+    if (removedEntry) {
+      removeArrayRewriteBucketEntry(working.buckets, removedEntry);
+    }
+    reindexArrayRewriteEntries(working.entries, index);
     return;
   }
 
   if (op.op === "replace") {
-    working[getArrayOpIndex(op.path, arrayPath)] = structuredClone(op.value);
+    const index = getArrayOpIndex(op.path, arrayPath);
+    const entry = working.entries[index]!;
+    removeArrayRewriteBucketEntry(working.buckets, entry);
+    entry.value = structuredClone(op.value);
+    entry.key = getArrayRewriteValueKey(working, op.value);
+    insertArrayRewriteBucketEntry(working.buckets, entry);
     return;
   }
 
   if (op.op === "copy") {
     const fromIndex = getArrayOpIndex(op.from, arrayPath);
-    if (fromIndex < 0 || fromIndex >= working.length) {
+    if (fromIndex < 0 || fromIndex >= working.entries.length) {
       throw new Error(
-        `applyArrayOptimizationOp: copy from index ${fromIndex} is out of bounds (length ${working.length})`,
+        `applyArrayOptimizationOp: copy from index ${fromIndex} is out of bounds (length ${working.entries.length})`,
       );
     }
 
-    const value = structuredClone(working[fromIndex]!);
-    working.splice(getArrayOpIndex(op.path, arrayPath), 0, value);
+    const index = getArrayOpIndex(op.path, arrayPath);
+    const source = working.entries[fromIndex]!;
+    const entry: ArrayRewriteEntry = {
+      value: structuredClone(source.value),
+      key: source.key,
+      currentIndex: index,
+    };
+    working.entries.splice(index, 0, entry);
+    insertArrayRewriteBucketEntry(working.buckets, entry);
+    reindexArrayRewriteEntries(working.entries, index + 1);
     return;
   }
 
   if (op.op === "move") {
     const fromIndex = getArrayOpIndex(op.from, arrayPath);
-    if (fromIndex < 0 || fromIndex >= working.length) {
+    if (fromIndex < 0 || fromIndex >= working.entries.length) {
       throw new Error(
-        `applyArrayOptimizationOp: move from index ${fromIndex} is out of bounds (length ${working.length})`,
+        `applyArrayOptimizationOp: move from index ${fromIndex} is out of bounds (length ${working.entries.length})`,
       );
     }
 
-    const [value] = working.splice(fromIndex, 1);
-    working.splice(getArrayOpIndex(op.path, arrayPath), 0, value!);
+    const [entry] = working.entries.splice(fromIndex, 1);
+    if (!entry) {
+      throw new Error(`applyArrayOptimizationOp: move from index ${fromIndex} did not resolve`);
+    }
+
+    removeArrayRewriteBucketEntry(working.buckets, entry);
+    const index = getArrayOpIndex(op.path, arrayPath);
+    entry.currentIndex = index;
+    working.entries.splice(index, 0, entry);
+    insertArrayRewriteBucketEntry(working.buckets, entry);
+    reindexArrayRewriteEntries(working.entries, Math.min(fromIndex, index));
     return;
   }
 

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -95,6 +95,11 @@ interface ArrayRewriteState {
   readonly structuralKeyCache: WeakMap<object, string>;
 }
 
+// Array rewrite comparisons should always use entry.key rather than
+// recomputing from entry.value. Add/copy/replace paths store a cloned value on
+// the entry, so the clone does not share WeakMap identity with the source used
+// to prime structuralKeyCache.
+
 /** Structured compile error used to map patch validation failures to typed reasons. */
 export class PatchCompileError extends Error {
   readonly reason: PatchErrorReason;

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -86,6 +86,7 @@ interface ArrayRewriteEntry {
   value: JsonValue;
   key: string;
   currentIndex: number;
+  bucketIndex: number;
 }
 
 interface ArrayRewriteState {
@@ -1290,6 +1291,7 @@ function createArrayRewriteState(base: JsonValue[]): ArrayRewriteState {
       value,
       key: stableJsonValueKey(value, structuralKeyCache),
       currentIndex,
+      bucketIndex: -1,
     };
     insertArrayRewriteBucketEntry(buckets, entry);
     return entry;
@@ -1329,6 +1331,7 @@ function insertArrayRewriteBucketEntry(
   }
 
   bucket.splice(low, 0, entry);
+  reindexArrayRewriteBucketPositions(bucket, low);
 }
 
 function removeArrayRewriteBucketEntry(
@@ -1340,14 +1343,25 @@ function removeArrayRewriteBucketEntry(
     return;
   }
 
-  const bucketIndex = bucket.indexOf(entry);
-  if (bucketIndex === -1) {
+  const bucketIndex = entry.bucketIndex;
+  if (bucketIndex < 0 || bucketIndex >= bucket.length || bucket[bucketIndex] !== entry) {
     return;
   }
 
   bucket.splice(bucketIndex, 1);
   if (bucket.length === 0) {
     buckets.delete(entry.key);
+    entry.bucketIndex = -1;
+    return;
+  }
+
+  entry.bucketIndex = -1;
+  reindexArrayRewriteBucketPositions(bucket, bucketIndex);
+}
+
+function reindexArrayRewriteBucketPositions(bucket: ArrayRewriteEntry[], startIndex: number): void {
+  for (let index = startIndex; index < bucket.length; index++) {
+    bucket[index]!.bucketIndex = index;
   }
 }
 
@@ -1389,10 +1403,11 @@ function applyArrayOptimizationOp(
       value,
       key: getArrayRewriteValueKey(working, op.value),
       currentIndex: index,
+      bucketIndex: -1,
     };
     working.entries.splice(index, 0, entry);
-    insertArrayRewriteBucketEntry(working.buckets, entry);
     reindexArrayRewriteEntries(working.entries, index + 1);
+    insertArrayRewriteBucketEntry(working.buckets, entry);
     return;
   }
 
@@ -1430,10 +1445,11 @@ function applyArrayOptimizationOp(
       value: structuredClone(source.value),
       key: source.key,
       currentIndex: index,
+      bucketIndex: -1,
     };
     working.entries.splice(index, 0, entry);
-    insertArrayRewriteBucketEntry(working.buckets, entry);
     reindexArrayRewriteEntries(working.entries, index + 1);
+    insertArrayRewriteBucketEntry(working.buckets, entry);
     return;
   }
 
@@ -1452,10 +1468,9 @@ function applyArrayOptimizationOp(
 
     removeArrayRewriteBucketEntry(working.buckets, entry);
     const index = getArrayOpIndex(op.path, arrayPath);
-    entry.currentIndex = index;
     working.entries.splice(index, 0, entry);
-    insertArrayRewriteBucketEntry(working.buckets, entry);
     reindexArrayRewriteEntries(working.entries, Math.min(fromIndex, index));
+    insertArrayRewriteBucketEntry(working.buckets, entry);
     return;
   }
 

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -825,6 +825,41 @@ describe("diffJsonPatch", () => {
     expect(applyJsonPatch(base, ops)).toEqual(next);
   });
 
+  it("keeps duplicate-heavy array move/copy rewrites deterministic across runs", () => {
+    const base: JsonValue = {
+      arr: [
+        { kind: "anchor", value: 0 },
+        { kind: "dup", value: 1 },
+        { kind: "dup", value: 2 },
+        { kind: "dup", value: 1 },
+        { kind: "dup", value: 2 },
+        { kind: "tail", value: 9 },
+      ],
+    };
+    const next: JsonValue = {
+      arr: [
+        { kind: "dup", value: 2 },
+        { kind: "anchor", value: 0 },
+        { kind: "dup", value: 1 },
+        { kind: "dup", value: 2 },
+        { kind: "dup", value: 1 },
+        { kind: "dup", value: 2 },
+        { kind: "tail", value: 9 },
+      ],
+    };
+
+    const options = {
+      arrayStrategy: "lcs",
+      emitMoves: true,
+      emitCopies: true,
+    } as const;
+    const patch1 = diffJsonPatch(base, next, options);
+    const patch2 = diffJsonPatch(base, next, options);
+
+    expect(patch1).toEqual(patch2);
+    expect(applyJsonPatch(base, patch1)).toEqual(next);
+  });
+
   it("can append elements with LCS", () => {
     const base: JsonValue = { arr: [1] };
     const next: JsonValue = { arr: [1, 2, 3] };

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -825,28 +825,9 @@ describe("diffJsonPatch", () => {
     expect(applyJsonPatch(base, ops)).toEqual(next);
   });
 
-  it("keeps duplicate-heavy array move/copy rewrites deterministic across runs", () => {
-    const base: JsonValue = {
-      arr: [
-        { kind: "anchor", value: 0 },
-        { kind: "dup", value: 1 },
-        { kind: "dup", value: 2 },
-        { kind: "dup", value: 1 },
-        { kind: "dup", value: 2 },
-        { kind: "tail", value: 9 },
-      ],
-    };
-    const next: JsonValue = {
-      arr: [
-        { kind: "dup", value: 2 },
-        { kind: "anchor", value: 0 },
-        { kind: "dup", value: 1 },
-        { kind: "dup", value: 2 },
-        { kind: "dup", value: 1 },
-        { kind: "dup", value: 2 },
-        { kind: "tail", value: 9 },
-      ],
-    };
+  it("keeps duplicate-heavy array move/copy rewrites deterministic and canonical across runs", () => {
+    const base: JsonValue = { arr: [0, 0, 1, 0, 2] };
+    const next: JsonValue = { arr: [1, 0, 0, 2, 0] };
 
     const options = {
       arrayStrategy: "lcs",
@@ -856,6 +837,11 @@ describe("diffJsonPatch", () => {
     const patch1 = diffJsonPatch(base, next, options);
     const patch2 = diffJsonPatch(base, next, options);
 
+    expect(patch1).toEqual([
+      { op: "remove", path: "/arr/0" },
+      { op: "move", from: "/arr/0", path: "/arr/2" },
+      { op: "copy", from: "/arr/1", path: "/arr/4" },
+    ]);
     expect(patch1).toEqual(patch2);
     expect(applyJsonPatch(base, patch1)).toEqual(next);
   });

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -62,6 +62,46 @@ describe("performance regressions", () => {
     expect(patch).toEqual([{ op: "replace", path: "/arr/750", value: -1 }]);
   });
 
+  it("avoids repeated deep equality rescans for duplicate-heavy array copy rewrites", () => {
+    const hits = { count: 0 };
+    const makeValue = (id: number): JsonValue => {
+      const value = {} as Record<string, JsonValue>;
+      Object.defineProperty(value, "id", {
+        enumerable: true,
+        get: () => {
+          hits.count += 1;
+          return id;
+        },
+      });
+      Object.defineProperty(value, "payload", {
+        enumerable: true,
+        get: () => {
+          hits.count += 1;
+          return [id % 5, id % 7, { tag: id % 11 }] as JsonValue;
+        },
+      });
+      return value as JsonValue;
+    };
+
+    const prefix = Array.from({ length: 120 }, (_, idx) => makeValue(idx));
+    const duplicateValues = Array.from({ length: 6 }, () => makeValue(9_999));
+    const base: JsonValue = { arr: [...prefix, duplicateValues[0]!, duplicateValues[1]!] };
+    const next: JsonValue = { arr: [...prefix, ...duplicateValues] };
+
+    const patch = diffJsonPatch(base, next, {
+      arrayStrategy: "lcs",
+      emitCopies: true,
+    });
+
+    expect(patch).toEqual([
+      { op: "copy", from: "/arr/120", path: "/arr/122" },
+      { op: "copy", from: "/arr/120", path: "/arr/123" },
+      { op: "copy", from: "/arr/120", path: "/arr/124" },
+      { op: "copy", from: "/arr/120", path: "/arr/125" },
+    ]);
+    expect(hits.count).toBeLessThan(700);
+  });
+
   it("still falls back to atomic replace when the unmatched LCS window is too large", () => {
     const baseArr = Array.from({ length: 600 }, (_, idx) => idx);
     const nextArr = [...baseArr].reverse();


### PR DESCRIPTION
## Summary
- replace finalize-time array rewrite rescans with an indexed shadow-array tracker keyed by stableJsonValueKey, so duplicate-heavy move/copy detection reuses candidate buckets instead of repeatedly walking the evolving working array
- add regression coverage for duplicate-heavy copy rewrites and a deterministic duplicate-heavy move/copy rewrite case
- extend bench/array-diff.microbench.ts with duplicate-heavy append, insert, and reorder workloads using emitCopies and emitMoves
- include a patch changeset for the rewrite optimization

## Issue
- Fixes #110

## Testing
- bun fmt
- bun lint:fix
- bun lint
- bun typecheck
- bun test
- BENCH_ARRAY_DIFF_MEDIUM_SIZE=200 BENCH_ARRAY_DIFF_LARGE_SIZE=300 BENCH_ARRAY_DIFF_DUPLICATE_SIZE=180 BENCH_ARRAY_DIFF_RUNS=2 bun run bench:array-diff

## Notes
- the new perf regression caps duplicate-heavy getter traversals on the copy rewrite path, which failed against the prior full-scan implementation
- the benchmark now exercises the duplicate-heavy append, insert, and reorder rewrite patterns called out in the issue acceptance criteria
