### PR TITLE
[codex] fix deep representative dots for kind-mismatch merge

### DIFF
--- a/.changeset/issue-122-merge-kind-mismatch.md
+++ b/.changeset/issue-122-merge-kind-mismatch.md
@@ -1,0 +1,10 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Fix kind-mismatch merge resolution so it considers the newest dot anywhere in the
+competing subtrees instead of only shallow container metadata.
+
+This preserves causally newer deep edits when they race with a concurrent
+replacement of the parent path by a different node kind, and adds a regression
+test covering the nested `/k/a/b` reproduction from Issue #122.

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -212,28 +212,50 @@ function maxObservedCtrForActor(doc: Doc, actor: ActorId, a: CrdtState, b: CrdtS
 }
 
 function repDot(node: Node): Dot {
-  switch (node.kind) {
-    case "lww":
-      return node.dot;
-    case "obj": {
-      // Use the max dot across all entries and tombstones.
-      let best: Dot = { actor: "", ctr: 0 };
-      for (const entry of node.entries.values()) {
-        if (compareDot(entry.dot, best) > 0) best = entry.dot;
-      }
-      for (const d of node.tombstone.values()) {
-        if (compareDot(d, best) > 0) best = d;
-      }
-      return best;
-    }
-    case "seq": {
-      let best: Dot = { actor: "", ctr: 0 };
-      for (const e of node.elems.values()) {
-        if (compareDot(e.insDot, best) > 0) best = e.insDot;
-      }
-      return best;
+  let best: Dot = { actor: "", ctr: 0 };
+  const stack: Array<{ node: Node; depth: number }> = [{ node, depth: 0 }];
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    assertTraversalDepth(frame.depth);
+
+    switch (frame.node.kind) {
+      case "lww":
+        if (compareDot(frame.node.dot, best) > 0) {
+          best = frame.node.dot;
+        }
+        break;
+      case "obj":
+        for (const entry of frame.node.entries.values()) {
+          if (compareDot(entry.dot, best) > 0) {
+            best = entry.dot;
+          }
+
+          stack.push({ node: entry.node, depth: frame.depth + 1 });
+        }
+        for (const tombstone of frame.node.tombstone.values()) {
+          if (compareDot(tombstone, best) > 0) {
+            best = tombstone;
+          }
+        }
+        break;
+      case "seq":
+        for (const elem of frame.node.elems.values()) {
+          if (compareDot(elem.insDot, best) > 0) {
+            best = elem.insDot;
+          }
+
+          if (elem.delDot && compareDot(elem.delDot, best) > 0) {
+            best = elem.delDot;
+          }
+
+          stack.push({ node: elem.value, depth: frame.depth + 1 });
+        }
+        break;
     }
   }
+
+  return best;
 }
 
 function mergeNode(a: Node, b: Node): Node {

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -277,13 +277,17 @@ describe("mergeDoc", () => {
     const nextKindReplace = applyPatch(kindReplace, [{ op: "replace", path: "/k", value: 0 }]);
 
     const merged = mergeDoc(nextDeepEdit.doc, nextKindReplace.doc);
-    expect(materialize(merged.root)).toEqual({
+    const mergedReversed = mergeDoc(nextKindReplace.doc, nextDeepEdit.doc);
+    const expected = {
       k: {
         a: {
           b: 2,
         },
       },
-    });
+    };
+
+    expect(materialize(merged.root)).toEqual(expected);
+    expect(materialize(mergedReversed.root)).toEqual(expected);
   });
 
   it("merges empty objects", () => {

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -259,6 +259,33 @@ describe("mergeDoc", () => {
     expect(materialize(merged.root)).toBe(42);
   });
 
+  it("preserves deeper subtree edits when resolving kind mismatch", () => {
+    const origin = createState(
+      {
+        k: {
+          a: {
+            b: 1,
+          },
+        },
+      },
+      { actor: "origin" },
+    );
+    const deepEdit = forkState(origin, "Z");
+    const kindReplace = forkState(origin, "A");
+
+    const nextDeepEdit = applyPatch(deepEdit, [{ op: "replace", path: "/k/a/b", value: 2 }]);
+    const nextKindReplace = applyPatch(kindReplace, [{ op: "replace", path: "/k", value: 0 }]);
+
+    const merged = mergeDoc(nextDeepEdit.doc, nextKindReplace.doc);
+    expect(materialize(merged.root)).toEqual({
+      k: {
+        a: {
+          b: 2,
+        },
+      },
+    });
+  });
+
   it("merges empty objects", () => {
     const a = docFromJson({}, newDotGen("A"));
     const b = docFromJson({}, newDotGen("B"));


### PR DESCRIPTION
## Summary
Fix kind-mismatch merge resolution so it compares the newest dot anywhere in each competing subtree instead of only shallow container metadata.

Closes #122.

## Root Cause
When `mergeDoc` had to resolve a node kind mismatch, `repDot(...)` only looked at shallow metadata:
- register dots for `lww`
- immediate entry and tombstone dots for `obj`
- insertion dots for `seq`

That let an older deep subtree edit lose to a newer shallow replacement of the parent path, because the deeper write was never considered during representative-dot selection.

## What Changed
- rewrote `repDot(...)` to traverse the full subtree iteratively
- included nested child nodes when computing the representative dot
- included sequence delete dots alongside insert dots during representative-dot selection
- added a regression test for the `/k/a/b` deep-write versus `/k` kind-replacement race from Issue #122
- added a patch changeset for release tracking

## Impact
This preserves causally newer deep edits during kind-mismatch merges and avoids dropping valid subtree state during convergence.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`