### PR TITLE
[codex] optimize validateJsonPatch to avoid extra immutable clone

### DIFF
--- a/.changeset/issue-124-lightweight-validate-json-patch.md
+++ b/.changeset/issue-124-lightweight-validate-json-patch.md
@@ -1,0 +1,4 @@
+"json-patch-to-crdt": patch
+---
+
+Optimize `validateJsonPatch` to use a private in-place validation path and avoid the extra immutable clone when validating patches against JSON input.

--- a/.changeset/issue-124-lightweight-validate-json-patch.md
+++ b/.changeset/issue-124-lightweight-validate-json-patch.md
@@ -1,3 +1,4 @@
+---
 "json-patch-to-crdt": patch
 ---
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -227,7 +227,7 @@ export function validateJsonPatch(
     actor: "__validate__",
     jsonValidation: options.jsonValidation,
   });
-  const result = tryApplyPatch(state, patch, options);
+  const result = tryApplyPatchInPlace(state, patch, { ...options, atomic: false });
   if (!result.ok) {
     return { ok: false, error: result.error };
   }

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -950,6 +950,19 @@ describe("clock and state", () => {
     expect(base).toEqual({ list: ["a"] });
   });
 
+  it("validates patches without mutating nested patch payloads", () => {
+    const base: JsonValue = { list: [] };
+    const payload = { nested: ["a"] };
+    const patch: JsonPatchOp[] = [{ op: "add", path: "/list/0", value: payload }];
+
+    const result = validateJsonPatch(base, patch);
+
+    expect(result).toEqual({ ok: true });
+    expect(base).toEqual({ list: [] });
+    expect(payload).toEqual({ nested: ["a"] });
+    expect(patch).toEqual([{ op: "add", path: "/list/0", value: { nested: ["a"] } }]);
+  });
+
   it("validates strict jsonValidation patch payloads", () => {
     const result = validateJsonPatch(
       {},


### PR DESCRIPTION
## Summary
- switch `validateJsonPatch` to the internal in-place apply path with `atomic: false`
- keep validation non-mutating for callers while avoiding the extra immutable clone step
- add a regression test covering nested patch payload values to prove validation does not mutate caller-owned data
- add a patch changeset for the validation-path optimization

## Root cause
`validateJsonPatch` already clones the input into a private validation state before applying the patch. It then called the immutable `tryApplyPatch` helper, which cloned that private state again. That duplicated work during validation even though the state was already isolated from the caller.

## What changed
The validation path now calls `tryApplyPatchInPlace(state, patch, { ...options, atomic: false })` instead of the immutable helper. Because the state passed into validation is already private, this preserves the public non-mutating contract while removing the redundant extra clone.

## Impact
This reduces overhead for `validateJsonPatch` on JSON inputs, especially when validating patches that include larger payloads, without changing the external API or mutating caller data.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun test`
- `bun run typecheck`

## Changeset
- patch release for `json-patch-to-crdt`

## Issue
- Closes #124