### PR TITLE
[codex] Fix sequential jsonPatchToCrdt rematerialization

### DIFF
--- a/.changeset/issue-125-sequential-internals-shadow.md
+++ b/.changeset/issue-125-sequential-internals-shadow.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Optimize `jsonPatchToCrdt` sequential compilation so it resolves paths directly from the rolling CRDT document view instead of materializing the full shadow document for each operation, and add a regression test that guards against rematerializing unrelated branches.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -24,7 +24,6 @@ import {
   PatchCompileError,
   compileJsonPatchToIntent,
   diffJsonPatch,
-  getAtJson,
   jsonEquals,
   parseJsonPointer,
   stringifyJsonPointer,
@@ -36,6 +35,7 @@ import {
   rgaDelete,
   rgaIdAtIndex,
   rgaInsertAfter,
+  rgaLength,
   rgaMaxInsertDotForPrev,
   rgaPrevForInsertAtIndex,
 } from "./rga";
@@ -1390,7 +1390,7 @@ function jsonPatchToCrdtInternal(options: JsonPatchToCrdtOptions): ApplyResult {
 
   // Sequential mode compiles each op against a rolling snapshot. `shadowBase`
   // tracks that compile-time view without mutating caller-provided `base`.
-  let shadowBase = cloneDoc(evalTestAgainst === "base" ? options.base : options.head);
+  const shadowBase = evalTestAgainst === "base" ? cloneDoc(options.base) : null;
   let shadowCtr = 0;
   const shadowDot = () => ({ actor: "__shadow__", ctr: ++shadowCtr });
   const shadowBump = (ctr: number) => {
@@ -1399,99 +1399,528 @@ function jsonPatchToCrdtInternal(options: JsonPatchToCrdtOptions): ApplyResult {
     }
   };
 
-  const applySequentialOp = (op: JsonPatchOp, opIndex: number): ApplyResult => {
-    const baseJson = materialize(shadowBase.root);
-    let intents: IntentOp[];
-    try {
-      intents = compileJsonPatchToIntent(baseJson, [op], {
-        semantics: "sequential",
-      });
-    } catch (error) {
-      return withOpIndex(toApplyError(error), opIndex);
-    }
-
-    const headStep = applyIntentsToCrdt(
-      shadowBase,
-      options.head,
-      intents,
-      options.newDot,
-      evalTestAgainst,
-      options.bumpCounterAbove,
-      { strictParents: options.strictParents },
-    );
-    if (!headStep.ok) {
-      return withOpIndex(headStep, opIndex);
-    }
-
-    if (evalTestAgainst === "base") {
-      // Keep the compile-time base in lockstep for future operations while using
-      // synthetic dots so we do not consume real actor counters.
-      const shadowStep = applyIntentsToCrdt(
-        shadowBase,
-        shadowBase,
-        intents,
-        shadowDot,
-        "base",
-        shadowBump,
-        { strictParents: options.strictParents },
-      );
-      if (!shadowStep.ok) {
-        return withOpIndex(shadowStep, opIndex);
-      }
-    } else {
-      shadowBase = cloneDoc(options.head);
-    }
-
-    return { ok: true };
+  const session: SequentialCompileSession = {
+    pointerCache: new Map(),
   };
 
-  for (let opIndex = 0; opIndex < options.patch.length; opIndex++) {
-    const op = options.patch[opIndex]!;
-    if (op.op === "move") {
-      const baseJson = materialize(shadowBase.root);
-      let fromValue: JsonValue;
-      try {
-        // Read the source before applying remove so move behaves as "copy then remove".
-        fromValue = structuredClone(getAtJson(baseJson, parseJsonPointer(op.from)));
-      } catch {
-        try {
-          compileJsonPatchToIntent(baseJson, [{ op: "remove", path: op.from }], {
-            semantics: "sequential",
-          });
-        } catch (error) {
-          return withOpIndex(toApplyError(error), opIndex);
-        }
-
-        return withOpIndex(
-          toApplyError(new Error(`failed to resolve move source at ${op.from}`)),
-          opIndex,
-        );
-      }
-
-      if (op.from === op.path) {
-        continue;
-      }
-
-      const removeStep = applySequentialOp({ op: "remove", path: op.from }, opIndex);
-      if (!removeStep.ok) {
-        return removeStep;
-      }
-
-      const addStep = applySequentialOp({ op: "add", path: op.path, value: fromValue }, opIndex);
-      if (!addStep.ok) {
-        return addStep;
-      }
-
-      continue;
-    }
-
-    const step = applySequentialOp(op, opIndex);
+  for (const [opIndex, op] of options.patch.entries()) {
+    const compileBase = evalTestAgainst === "base" ? shadowBase! : options.head;
+    const step = applySequentialPatchOp(
+      options,
+      compileBase,
+      op,
+      opIndex,
+      evalTestAgainst,
+      shadowDot,
+      shadowBump,
+      session,
+    );
     if (!step.ok) {
       return step;
     }
   }
 
   return { ok: true };
+}
+
+type SequentialCompileSession = {
+  pointerCache: Map<string, string[]>;
+};
+
+function applySequentialPatchOp(
+  options: JsonPatchToCrdtOptions,
+  compileBase: Doc,
+  op: JsonPatchOp,
+  opIndex: number,
+  evalTestAgainst: "head" | "base",
+  shadowDot: () => Dot,
+  shadowBump: (ctr: number) => void,
+  session: SequentialCompileSession,
+): ApplyResult {
+  if (op.op === "move") {
+    if (op.from === op.path) {
+      return { ok: true };
+    }
+
+    const fromResolved = resolveValueAtPointerInDoc(
+      compileBase,
+      op.from,
+      opIndex,
+      session.pointerCache,
+    );
+    if (!fromResolved.ok) {
+      return fromResolved;
+    }
+
+    const removeStep = applySingleSequentialPatchStep(
+      options,
+      compileBase,
+      { op: "remove", path: op.from },
+      opIndex,
+      evalTestAgainst,
+      shadowDot,
+      shadowBump,
+      session,
+    );
+    if (!removeStep.ok) {
+      return removeStep;
+    }
+
+    return applySingleSequentialPatchStep(
+      options,
+      compileBase,
+      { op: "add", path: op.path, value: structuredClone(fromResolved.value) },
+      opIndex,
+      evalTestAgainst,
+      shadowDot,
+      shadowBump,
+      session,
+    );
+  }
+
+  if (op.op === "copy") {
+    const fromResolved = resolveValueAtPointerInDoc(
+      compileBase,
+      op.from,
+      opIndex,
+      session.pointerCache,
+    );
+    if (!fromResolved.ok) {
+      return fromResolved;
+    }
+
+    return applySingleSequentialPatchStep(
+      options,
+      compileBase,
+      { op: "add", path: op.path, value: structuredClone(fromResolved.value) },
+      opIndex,
+      evalTestAgainst,
+      shadowDot,
+      shadowBump,
+      session,
+    );
+  }
+
+  return applySingleSequentialPatchStep(
+    options,
+    compileBase,
+    op,
+    opIndex,
+    evalTestAgainst,
+    shadowDot,
+    shadowBump,
+    session,
+  );
+}
+
+function applySingleSequentialPatchStep(
+  options: JsonPatchToCrdtOptions,
+  compileBase: Doc,
+  op: Exclude<JsonPatchOp, { op: "move" | "copy" }>,
+  opIndex: number,
+  evalTestAgainst: "head" | "base",
+  shadowDot: () => Dot,
+  shadowBump: (ctr: number) => void,
+  session: SequentialCompileSession,
+): ApplyResult {
+  const compiled = compilePreparedSingleIntentFromDoc(
+    compileBase,
+    op,
+    session.pointerCache,
+    opIndex,
+  );
+  if (!compiled.ok) {
+    return compiled;
+  }
+
+  const headStep = applyIntentsToCrdt(
+    compileBase,
+    options.head,
+    compiled.intents,
+    options.newDot,
+    evalTestAgainst,
+    options.bumpCounterAbove,
+    { strictParents: options.strictParents },
+  );
+  if (!headStep.ok) {
+    return withOpIndex(headStep, opIndex);
+  }
+
+  if (op.op === "test") {
+    return { ok: true };
+  }
+
+  if (evalTestAgainst === "head") {
+    return { ok: true };
+  }
+
+  const shadowStep = applyIntentsToCrdt(
+    compileBase,
+    compileBase,
+    compiled.intents,
+    shadowDot,
+    "base",
+    shadowBump,
+    { strictParents: options.strictParents },
+  );
+  if (!shadowStep.ok) {
+    return withOpIndex(shadowStep, opIndex);
+  }
+
+  return { ok: true };
+}
+
+function resolveValueAtPointerInDoc(
+  doc: Doc,
+  pointer: string,
+  opIndex: number,
+  pointerCache: Map<string, string[]>,
+): { ok: true; value: JsonValue } | ApplyError {
+  const parsedPath = parsePointerWithCache(pointer, pointerCache, opIndex);
+  if (!parsedPath.ok) {
+    return parsedPath;
+  }
+
+  const resolved = resolveNodeAtPath(doc.root, parsedPath.path);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      ...resolved.error,
+      path: pointer,
+      opIndex,
+    };
+  }
+
+  return {
+    ok: true,
+    value: nodeToJsonForPatch(resolved.node),
+  };
+}
+
+function compilePreparedSingleIntentFromDoc(
+  baseDoc: Doc,
+  op: Exclude<JsonPatchOp, { op: "move" | "copy" }>,
+  pointerCache: Map<string, string[]>,
+  opIndex: number,
+): { ok: true; intents: IntentOp[] } | ApplyError {
+  const parsedPath = parsePointerWithCache(op.path, pointerCache, opIndex);
+  if (!parsedPath.ok) {
+    return parsedPath;
+  }
+
+  const path = parsedPath.path;
+  if (op.op === "test") {
+    return {
+      ok: true,
+      intents: [{ t: "Test", path, value: op.value }],
+    };
+  }
+
+  if (path.length === 0) {
+    if (op.op === "remove") {
+      return {
+        ok: false,
+        code: 409,
+        reason: "INVALID_TARGET",
+        message: "remove at root path is not supported in RFC-compliant mode",
+        path: op.path,
+        opIndex,
+      };
+    }
+
+    return {
+      ok: true,
+      intents: [{ t: "ObjSet", path: [], key: ROOT_KEY, value: op.value }],
+    };
+  }
+
+  const parentPath = path.slice(0, -1);
+  const parentPointer = stringifyJsonPointer(parentPath);
+  const key = path[path.length - 1]!;
+  const resolvedParent =
+    parentPath.length === 0
+      ? { ok: true as const, node: baseDoc.root }
+      : resolveNodeAtPath(baseDoc.root, parentPath);
+  if (!resolvedParent.ok) {
+    return {
+      ok: false,
+      ...resolvedParent.error,
+      path: parentPointer,
+      opIndex,
+    };
+  }
+
+  const parentNode = resolvedParent.node;
+  if (parentNode.kind === "seq") {
+    const parsedIndex = parseArrayIndexTokenForDoc(key, op.op, op.path, opIndex);
+    if (!parsedIndex.ok) {
+      return parsedIndex;
+    }
+
+    const boundedIndex = validateArrayIndexBounds(
+      parsedIndex.index,
+      op.op,
+      rgaLength(parentNode),
+      op.path,
+      opIndex,
+    );
+    if (!boundedIndex.ok) {
+      return boundedIndex;
+    }
+
+    if (op.op === "add") {
+      return {
+        ok: true,
+        intents: [{ t: "ArrInsert", path: parentPath, index: boundedIndex.index, value: op.value }],
+      };
+    }
+
+    if (op.op === "remove") {
+      return {
+        ok: true,
+        intents: [{ t: "ArrDelete", path: parentPath, index: boundedIndex.index }],
+      };
+    }
+
+    return {
+      ok: true,
+      intents: [{ t: "ArrReplace", path: parentPath, index: boundedIndex.index, value: op.value }],
+    };
+  }
+
+  if (parentNode.kind !== "obj") {
+    return {
+      ok: false,
+      code: 409,
+      reason: "INVALID_TARGET",
+      message: `expected object or array parent at ${parentPointer}`,
+      path: parentPointer,
+      opIndex,
+    };
+  }
+
+  if (key === "__proto__") {
+    return {
+      ok: false,
+      code: 409,
+      reason: "INVALID_POINTER",
+      message: `unsafe object key at ${op.path}`,
+      path: op.path,
+      opIndex,
+    };
+  }
+
+  const entry = parentNode.entries.get(key);
+  if ((op.op === "replace" || op.op === "remove") && !entry) {
+    return {
+      ok: false,
+      code: 409,
+      reason: "MISSING_TARGET",
+      message: `missing key ${key} at ${parentPointer}`,
+      path: op.path,
+      opIndex,
+    };
+  }
+
+  if (op.op === "remove") {
+    return {
+      ok: true,
+      intents: [{ t: "ObjRemove", path: parentPath, key }],
+    };
+  }
+
+  return {
+    ok: true,
+    intents: [{ t: "ObjSet", path: parentPath, key, value: op.value, mode: op.op }],
+  };
+}
+
+function parsePointerWithCache(
+  pointer: string,
+  pointerCache: Map<string, string[]>,
+  opIndex: number,
+): { ok: true; path: string[] } | ApplyError {
+  const cachedPath = pointerCache.get(pointer);
+  if (cachedPath !== undefined) {
+    return { ok: true, path: cachedPath.slice() };
+  }
+
+  try {
+    const parsedPath = parseJsonPointer(pointer);
+    pointerCache.set(pointer, parsedPath);
+    return { ok: true, path: parsedPath.slice() };
+  } catch (error) {
+    return {
+      ok: false,
+      code: 409,
+      reason: "INVALID_POINTER",
+      message: error instanceof Error ? error.message : "invalid pointer",
+      path: pointer,
+      opIndex,
+    };
+  }
+}
+
+function resolveNodeAtPath(
+  root: Node,
+  path: string[],
+):
+  | { ok: true; node: Node }
+  | { ok: false; error: Omit<ApplyError, "ok" | "code"> & { code: 409 } } {
+  let current = root;
+
+  for (const segment of path) {
+    if (current.kind === "obj") {
+      const entry = current.entries.get(segment);
+      if (!entry) {
+        return {
+          ok: false,
+          error: {
+            code: 409,
+            reason: "MISSING_PARENT",
+            message: `Missing key '${segment}'`,
+          },
+        };
+      }
+
+      current = entry.node;
+      continue;
+    }
+
+    if (current.kind === "seq") {
+      if (!ARRAY_INDEX_TOKEN_PATTERN.test(segment)) {
+        return {
+          ok: false,
+          error: {
+            code: 409,
+            reason: "INVALID_POINTER",
+            message: `Expected array index, got '${segment}'`,
+          },
+        };
+      }
+
+      const index = Number(segment);
+      if (!Number.isSafeInteger(index)) {
+        return {
+          ok: false,
+          error: {
+            code: 409,
+            reason: "OUT_OF_BOUNDS",
+            message: `Index out of bounds at '${segment}'`,
+          },
+        };
+      }
+
+      const elemId = rgaIdAtIndex(current, index);
+      if (elemId === undefined) {
+        return {
+          ok: false,
+          error: {
+            code: 409,
+            reason: "OUT_OF_BOUNDS",
+            message: `Index out of bounds at '${segment}'`,
+          },
+        };
+      }
+
+      current = current.elems.get(elemId)!.value;
+      continue;
+    }
+
+    return {
+      ok: false,
+      error: {
+        code: 409,
+        reason: "INVALID_TARGET",
+        message: `Cannot traverse into non-container at '${segment}'`,
+      },
+    };
+  }
+
+  return { ok: true, node: current };
+}
+
+function parseArrayIndexTokenForDoc(
+  token: string,
+  op: "add" | "remove" | "replace",
+  path: string,
+  opIndex: number,
+): { ok: true; index: number } | ApplyError {
+  if (token === "-") {
+    if (op !== "add") {
+      return {
+        ok: false,
+        code: 409,
+        reason: "INVALID_POINTER",
+        message: `'-' index is only valid for add at ${path}`,
+        path,
+        opIndex,
+      };
+    }
+
+    return { ok: true, index: Number.POSITIVE_INFINITY };
+  }
+
+  if (!ARRAY_INDEX_TOKEN_PATTERN.test(token)) {
+    return {
+      ok: false,
+      code: 409,
+      reason: "INVALID_POINTER",
+      message: `expected array index at ${path}`,
+      path,
+      opIndex,
+    };
+  }
+
+  const index = Number(token);
+  if (!Number.isSafeInteger(index)) {
+    return {
+      ok: false,
+      code: 409,
+      reason: "OUT_OF_BOUNDS",
+      message: `array index is too large at ${path}`,
+      path,
+      opIndex,
+    };
+  }
+
+  return { ok: true, index };
+}
+
+function validateArrayIndexBounds(
+  index: number,
+  op: "add" | "remove" | "replace",
+  arrLength: number,
+  path: string,
+  opIndex: number,
+): { ok: true; index: number } | ApplyError {
+  if (op === "add") {
+    if (index === Number.POSITIVE_INFINITY) {
+      return { ok: true, index };
+    }
+
+    if (index > arrLength) {
+      return {
+        ok: false,
+        code: 409,
+        reason: "OUT_OF_BOUNDS",
+        message: `index out of bounds at ${path}; expected 0..${arrLength}`,
+        path,
+        opIndex,
+      };
+    }
+  } else if (index >= arrLength) {
+    return {
+      ok: false,
+      code: 409,
+      reason: "OUT_OF_BOUNDS",
+      message: `index out of bounds at ${path}; expected 0..${Math.max(arrLength - 1, 0)}`,
+      path,
+      opIndex,
+    };
+  }
+
+  return { ok: true, index };
 }
 
 function withOpIndex(error: ApplyError, opIndex: number): ApplyError {

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -1439,6 +1439,16 @@ function applySequentialPatchOp(
 ): ApplyResult {
   if (op.op === "move") {
     if (op.from === op.path) {
+      const pathCheck = resolveValueAtPointerInDoc(
+        compileBase,
+        op.from,
+        opIndex,
+        session.pointerCache,
+      );
+      if (!pathCheck.ok) {
+        return pathCheck;
+      }
+
       return { ok: true };
     }
 

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -1331,6 +1331,22 @@ describe("jsonPatchToCrdt", () => {
     expect(materialize(headDoc.root)).toEqual({ a: 1 });
   });
 
+  it("rejects self-move when the source path does not exist", () => {
+    const baseJson: JsonValue = {};
+    const baseDoc = docFromJsonWithDot(baseJson, dot("A", 0));
+    const headDoc = cloneDoc(baseDoc);
+    const patch: JsonPatchOp[] = [{ op: "move", from: "/missing", path: "/missing" }];
+
+    const res = jsonPatchToCrdt(baseDoc, headDoc, patch, newDotGen("A", 1));
+    expect(res.ok).toBeFalse();
+    if (!res.ok) {
+      expect(res.reason).toBe("MISSING_PARENT");
+      expect(res.path).toBe("/missing");
+      expect(res.opIndex).toBe(0);
+    }
+    expect(materialize(headDoc.root)).toEqual({});
+  });
+
   it("matches applyPatch for sequential move edge cases", () => {
     const patch: JsonPatchOp[] = [{ op: "move", from: "/list/0", path: "/list/2" }];
     const state = createState({ list: ["a", "b", "c"] }, { actor: "A" });

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -16,6 +16,8 @@ import {
   cloneDoc,
   compileJsonPatchToIntent,
   docFromJson,
+  jsonPatchToCrdt,
+  materialize,
   stableJsonValueKey,
 } from "../src/internals";
 import { setMaterializeObserverForTests } from "../src/materialize";
@@ -371,6 +373,66 @@ describe("performance regressions", () => {
       nested: { label: "v2499", even: false },
     });
 
+    expect(untouchedMaterializeCalls).toBe(0);
+  });
+
+  it("avoids eager full-document materialization in jsonPatchToCrdt sequential mode", () => {
+    const huge = Array.from({ length: 2_500 }, (_, idx) => ({
+      idx,
+      nested: { label: `v${idx}`, even: idx % 2 === 0 },
+    }));
+    const baseJson: JsonValue = {
+      meta: { version: 0 },
+      untouched: {
+        huge,
+      },
+    };
+    let ctr = 0;
+    const nextDot = () => ({ actor: "perf", ctr: ++ctr });
+    const baseDoc = docFromJson(baseJson, nextDot);
+    const headDoc = cloneDoc(baseDoc);
+    let untouchedMaterializeCalls = 0;
+
+    expect(
+      jsonPatchToCrdt({
+        base: baseDoc,
+        head: headDoc,
+        patch: [{ op: "replace", path: "/meta/version", value: 1 }],
+        newDot: nextDot,
+        semantics: "sequential",
+      }),
+    ).toEqual({ ok: true });
+
+    setMaterializeObserverForTests((path, node) => {
+      if (
+        node.kind === "seq" &&
+        path.length === 2 &&
+        path[0] === "untouched" &&
+        path[1] === "huge"
+      ) {
+        untouchedMaterializeCalls += 1;
+      }
+    });
+
+    try {
+      expect(
+        jsonPatchToCrdt({
+          base: baseDoc,
+          head: headDoc,
+          patch: [{ op: "replace", path: "/meta/version", value: 2 }],
+          newDot: nextDot,
+          evalTestAgainst: "base",
+          semantics: "sequential",
+        }),
+      ).toEqual({ ok: true });
+    } finally {
+      setMaterializeObserverForTests(null);
+    }
+
+    expect(materialize(headDoc.root)).toEqual({
+      meta: { version: 2 },
+      untouched: { huge },
+    });
     expect(untouchedMaterializeCalls).toBe(0);
   });
 


### PR DESCRIPTION
## Summary
Fixes Issue #125 by removing per-operation full-document materialization from `jsonPatchToCrdt(...)` sequential mode.

## What changed
- compile sequential `jsonPatchToCrdt` ops directly from the rolling CRDT document view instead of materializing `shadowBase` for every step
- add direct pointer-cache and CRDT-path resolution helpers for single-op sequential compilation in `src/doc.ts`
- keep head-evaluated sequential batches aligned with the live head document so array element identities stay stable across inserts, replaces, and removes
- add a performance regression test that verifies narrow sequential patches do not materialize unrelated large branches
- add the required changeset entry

## Why
The low-level sequential internals path was still scaling with repeated full shadow materialization even when each patch op only touched a narrow part of the document. The higher-level state API had already been optimized more aggressively, so this remained the main hotspot described in #125.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Closes #125