### PR TITLE
[codex] Finish CRDT-native array diffing for localized sequence edits

### DIFF
--- a/.changeset/issue-126-crdt-native-array-diff.md
+++ b/.changeset/issue-126-crdt-native-array-diff.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Extend `crdtToJsonPatch` with a CRDT-native sequence diff path that trims unchanged array prefixes and suffixes before materializing only the edited window, and add a regression test covering localized array edits around unchanged cyclic shared elements.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -1106,6 +1106,71 @@ function rebaseDiffOps(path: string[], nestedOps: JsonPatchOp[], out: JsonPatchO
   }
 }
 
+function collectLiveSequenceElements(seq: RgaSeq): RgaElem[] {
+  const elems: RgaElem[] = [];
+  const cursor = rgaCreateLinearCursor(seq);
+
+  for (let elem = cursor.next(); elem; elem = cursor.next()) {
+    elems.push(elem);
+  }
+
+  return elems;
+}
+
+function materializeSequenceWindow(
+  elems: readonly RgaElem[],
+  start: number,
+  end: number,
+): JsonValue[] {
+  const out: JsonValue[] = [];
+
+  for (let i = start; i < end; i++) {
+    out.push(nodeToJsonForPatch(elems[i]!.value));
+  }
+
+  return out;
+}
+
+function rebaseSequenceWindowDiffOps(
+  path: string[],
+  indexOffset: number,
+  nestedOps: JsonPatchOp[],
+  out: JsonPatchOp[],
+): boolean {
+  for (const op of nestedOps) {
+    if (op.path === "") {
+      return false;
+    }
+
+    const rebasedSegments = parseJsonPointer(op.path);
+    const indexToken = rebasedSegments[0];
+    if (!indexToken || !ARRAY_INDEX_TOKEN_PATTERN.test(indexToken)) {
+      return false;
+    }
+
+    rebasedSegments[0] = String(Number(indexToken) + indexOffset);
+    const rebasedPath = stringifyJsonPointer([...path, ...rebasedSegments]);
+
+    if (op.op === "remove") {
+      out.push({ op: "remove", path: rebasedPath });
+      continue;
+    }
+
+    if (op.op === "add" || op.op === "replace") {
+      out.push({
+        op: op.op,
+        path: rebasedPath,
+        value: op.value,
+      });
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
 function nodesJsonEqual(baseNode: Node, headNode: Node, depth: number): boolean {
   assertTraversalDepth(depth);
 
@@ -1276,6 +1341,75 @@ function diffObjectNodes(
   }
 }
 
+function diffSequenceNodes(
+  path: string[],
+  baseNode: RgaSeq,
+  headSeq: RgaSeq,
+  options: DiffOptions,
+  ops: JsonPatchOp[],
+  depth: number,
+): void {
+  const arrayStrategy = options.arrayStrategy ?? "lcs";
+  if (arrayStrategy === "atomic") {
+    const seqOps = diffJsonPatch(materialize(baseNode), materialize(headSeq), options);
+    rebaseDiffOps(path, seqOps, ops);
+    return;
+  }
+
+  const baseElems = collectLiveSequenceElements(baseNode);
+  const headElems = collectLiveSequenceElements(headSeq);
+  const sharedLength = Math.min(baseElems.length, headElems.length);
+
+  let prefixLength = 0;
+  while (
+    prefixLength < sharedLength &&
+    nodesJsonEqual(baseElems[prefixLength]!.value, headElems[prefixLength]!.value, depth + 1)
+  ) {
+    prefixLength += 1;
+  }
+
+  if (prefixLength === baseElems.length && prefixLength === headElems.length) {
+    return;
+  }
+
+  let baseEnd = baseElems.length;
+  let headEnd = headElems.length;
+  while (
+    baseEnd > prefixLength &&
+    headEnd > prefixLength &&
+    nodesJsonEqual(baseElems[baseEnd - 1]!.value, headElems[headEnd - 1]!.value, depth + 1)
+  ) {
+    baseEnd -= 1;
+    headEnd -= 1;
+  }
+
+  const unmatchedBaseLength = baseEnd - prefixLength;
+  const unmatchedHeadLength = headEnd - prefixLength;
+  if (unmatchedBaseLength === 1 && unmatchedHeadLength === 1) {
+    path.push(String(prefixLength));
+    diffNodeToPatch(
+      path,
+      baseElems[prefixLength]!.value,
+      headElems[prefixLength]!.value,
+      options,
+      ops,
+      depth + 1,
+    );
+    path.pop();
+    return;
+  }
+
+  const baseWindow = materializeSequenceWindow(baseElems, prefixLength, baseEnd);
+  const headWindow = materializeSequenceWindow(headElems, prefixLength, headEnd);
+  const seqOps = diffJsonPatch(baseWindow, headWindow, options);
+  if (rebaseSequenceWindowDiffOps(path, prefixLength, seqOps, ops)) {
+    return;
+  }
+
+  const fallbackSeqOps = diffJsonPatch(materialize(baseNode), materialize(headSeq), options);
+  rebaseDiffOps(path, fallbackSeqOps, ops);
+}
+
 function diffNodeToPatch(
   path: string[],
   baseNode: Node,
@@ -1321,9 +1455,7 @@ function diffNodeToPatch(
     return;
   }
 
-  const headSeq = headNode as RgaSeq;
-  const seqOps = diffJsonPatch(materialize(baseNode), materialize(headSeq), options);
-  rebaseDiffOps(path, seqOps, ops);
+  diffSequenceNodes(path, baseNode as RgaSeq, headNode as RgaSeq, options, ops, depth);
 }
 
 /**

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -1137,6 +1137,8 @@ function rebaseSequenceWindowDiffOps(
   nestedOps: JsonPatchOp[],
   out: JsonPatchOp[],
 ): boolean {
+  const pending: JsonPatchOp[] = [];
+
   for (const op of nestedOps) {
     if (op.path === "") {
       return false;
@@ -1152,12 +1154,12 @@ function rebaseSequenceWindowDiffOps(
     const rebasedPath = stringifyJsonPointer([...path, ...rebasedSegments]);
 
     if (op.op === "remove") {
-      out.push({ op: "remove", path: rebasedPath });
+      pending.push({ op: "remove", path: rebasedPath });
       continue;
     }
 
     if (op.op === "add" || op.op === "replace") {
-      out.push({
+      pending.push({
         op: op.op,
         path: rebasedPath,
         value: op.value,
@@ -1168,6 +1170,7 @@ function rebaseSequenceWindowDiffOps(
     return false;
   }
 
+  out.push(...pending);
   return true;
 }
 

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -1656,6 +1656,25 @@ describe("crdtToJsonPatch", () => {
     ).toThrow(TraversalDepthError);
   });
 
+  it("falls back cleanly when a rebased array window diff emits copy operations", () => {
+    const baseJson: JsonValue = { list: ["anchor", 0, "tail"] };
+    const headJson: JsonValue = { list: ["anchor", 0, 1, 0, "tail"] };
+    const base = docFromJsonWithDot(baseJson, dot("A", 1));
+    const head = docFromJsonWithDot(headJson, dot("B", 1));
+
+    const patch = crdtToJsonPatch(base, head, {
+      arrayStrategy: "lcs",
+      emitMoves: true,
+      emitCopies: true,
+    });
+
+    expect(patch).toEqual([
+      { op: "add", path: "/list/2", value: 1 },
+      { op: "add", path: "/list/3", value: 0 },
+    ]);
+    expect(applyJsonPatch(baseJson, patch)).toEqual(headJson);
+  });
+
   it("keeps object depth accounting aligned with materialize traversal limits", () => {
     const baseRoot = newObj();
     objSet(baseRoot, "child", newReg(1, dot("A", 1)), dot("A", 2));

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -1618,6 +1618,44 @@ describe("crdtToJsonPatch", () => {
     ).toThrow(TraversalDepthError);
   });
 
+  it("diffs localized array edits without materializing unchanged shared sequence elements", () => {
+    const shared = newObj();
+    objSet(shared, "self", shared, dot("A", 1));
+
+    const baseSeq = newSeq();
+    rgaInsertAfter(baseSeq, HEAD, dotToElemId(dot("A", 2)), dot("A", 2), shared);
+    rgaInsertAfter(
+      baseSeq,
+      dotToElemId(dot("A", 2)),
+      dotToElemId(dot("A", 3)),
+      dot("A", 3),
+      newReg(1, dot("A", 3)),
+    );
+
+    const headSeq = newSeq();
+    rgaInsertAfter(headSeq, HEAD, dotToElemId(dot("A", 2)), dot("A", 2), shared);
+    rgaInsertAfter(
+      headSeq,
+      dotToElemId(dot("A", 2)),
+      dotToElemId(dot("A", 4)),
+      dot("A", 4),
+      newReg(2, dot("A", 4)),
+    );
+
+    const baseRoot = newObj();
+    objSet(baseRoot, "list", baseSeq, dot("A", 5));
+
+    const headRoot = newObj();
+    objSet(headRoot, "list", headSeq, dot("A", 6));
+
+    expect(crdtToJsonPatch({ root: baseRoot }, { root: headRoot })).toEqual([
+      { op: "replace", path: "/list/1", value: 2 },
+    ]);
+    expect(() =>
+      crdtToJsonPatch({ root: baseRoot }, { root: headRoot }, { jsonValidation: "strict" }),
+    ).toThrow(TraversalDepthError);
+  });
+
   it("keeps object depth accounting aligned with materialize traversal limits", () => {
     const baseRoot = newObj();
     objSet(baseRoot, "child", newReg(1, dot("A", 1)), dot("A", 2));


### PR DESCRIPTION
## Summary
- extend `crdtToJsonPatch` with a sequence-native diff path that trims unchanged array prefixes and suffixes before materializing only the edited window
- keep the existing full-materialization fallback for `arrayStrategy: "atomic"` and for any window diff that cannot be safely rebased back onto the parent array path
- add a regression test covering a localized array edit next to an unchanged cyclic shared element

## Why
Issue #126 calls out that sequence diffs still fall back to `materialize(baseSeq)` and `materialize(headSeq)` even when the CRDT layer already exposes enough structure to isolate a localized edit. That full materialization does unnecessary work on large arrays and can traverse unrelated unchanged subtrees.

## Root Cause
The object-native path in `crdtToJsonPatch` already avoids materializing unchanged subtrees, but the sequence branch always delegated to `diffJsonPatch` with fully materialized arrays. That meant even a single localized array edit paid the cost of rebuilding both full JSON arrays first.

## Impact
Localized sequence edits now stay on a CRDT-native path for longer, so long-lived documents with large arrays avoid rematerializing unchanged prefixes and suffixes. The new regression test also proves we no longer need to traverse unchanged cyclic shared elements just to emit a narrow array delta.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Refs #126