### PR TITLE
[codex] Avoid observer-only path allocations in materialize hot paths

### DIFF
--- a/.changeset/issue-127-materialize-observer-paths.md
+++ b/.changeset/issue-127-materialize-observer-paths.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Avoid cloning `materialize` observer path arrays unless the test-only materialize observer is installed, and add a regression test that guards the hot path against observer-only path allocation work.

--- a/src/materialize.ts
+++ b/src/materialize.ts
@@ -6,6 +6,7 @@ import { rgaCreateLinearCursor } from "./rga";
 type MaterializeObserver = (path: readonly string[], node: Node) => void;
 
 let materializeObserver: MaterializeObserver | null = null;
+const EMPTY_PATH: readonly string[] = [];
 
 export function setMaterializeObserverForTests(observer: MaterializeObserver | null): void {
   materializeObserver = observer;
@@ -31,7 +32,7 @@ function setMaterializedProperty(
 /** Convert a CRDT node graph into a plain JSON value using an explicit stack. */
 export function materialize(node: Node): JsonValue {
   const observer = materializeObserver;
-  observer?.([], node);
+  observer?.(EMPTY_PATH, node);
 
   if (node.kind === "lww") {
     return node.value;
@@ -88,7 +89,7 @@ export function materialize(node: Node): JsonValue {
       const child = entry.node;
       const childDepth = frame.depth + 1;
       assertTraversalDepth(childDepth);
-      const childPath = [...frame.path, key];
+      const childPath = observer ? [...frame.path, key] : EMPTY_PATH;
       observer?.(childPath, child);
 
       if (child.kind === "lww") {
@@ -131,7 +132,7 @@ export function materialize(node: Node): JsonValue {
     const child = elem.value;
     const childDepth = frame.depth + 1;
     assertTraversalDepth(childDepth);
-    const childPath = [...frame.path, String(frame.nextIndex)];
+    const childPath = observer ? [...frame.path, String(frame.nextIndex)] : EMPTY_PATH;
     frame.nextIndex += 1;
     observer?.(childPath, child);
 

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -543,14 +543,16 @@ describe("mergeState", () => {
       expect(nonThrowing.error.reason).toBe("MAX_DEPTH_EXCEEDED");
     }
 
-    expect(() => mergeState(a, b)).toThrow(MergeError);
+    let thrown: unknown;
     try {
       mergeState(a, b);
     } catch (error) {
-      expect(error).toBeInstanceOf(MergeError);
-      if (error instanceof MergeError) {
-        expect(error.reason).toBe("MAX_DEPTH_EXCEEDED");
-      }
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(MergeError);
+    if (thrown instanceof MergeError) {
+      expect(thrown.reason).toBe("MAX_DEPTH_EXCEEDED");
     }
   });
 

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -436,6 +436,53 @@ describe("performance regressions", () => {
     expect(untouchedMaterializeCalls).toBe(0);
   });
 
+  it("avoids observer path-array cloning when no materialize observer is installed", () => {
+    const value: JsonValue = {
+      alpha: {
+        beta: {
+          gamma: 1,
+          delta: 2,
+        },
+      },
+      epsilon: {
+        zeta: 3,
+      },
+    };
+    const doc = docFromJson(
+      value,
+      (() => {
+        let ctr = 0;
+        return () => ({ actor: "perf", ctr: ++ctr });
+      })(),
+    );
+    const originalIterator = Array.prototype[Symbol.iterator];
+    let pathArrayIteratorCalls = 0;
+
+    Object.defineProperty(Array.prototype, Symbol.iterator, {
+      configurable: true,
+      value: function iterator(this: unknown[]): ArrayIterator<unknown> {
+        if (this.every((value) => typeof value === "string")) {
+          pathArrayIteratorCalls += 1;
+        }
+        return originalIterator.call(this);
+      },
+    });
+
+    let materialized: JsonValue;
+    try {
+      setMaterializeObserverForTests(null);
+      materialized = materialize(doc.root);
+    } finally {
+      Object.defineProperty(Array.prototype, Symbol.iterator, {
+        configurable: true,
+        value: originalIterator,
+      });
+    }
+
+    expect(materialized!).toEqual(value);
+    expect(pathArrayIteratorCalls).toBe(0);
+  });
+
   it("compacts high-volume stable tombstones without changing materialized output", () => {
     const initial: Record<string, JsonValue> = {};
     for (let i = 0; i < 400; i++) {

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -461,7 +461,7 @@ describe("performance regressions", () => {
     Object.defineProperty(Array.prototype, Symbol.iterator, {
       configurable: true,
       value: function iterator(this: unknown[]): ArrayIterator<unknown> {
-        if (this.every((value) => typeof value === "string")) {
+        if (this.length > 0 && this.every((value) => typeof value === "string")) {
           pathArrayIteratorCalls += 1;
         }
         return originalIterator.call(this);


### PR DESCRIPTION
## Summary
- avoid cloning `materialize` child-path arrays unless the test-only materialize observer is installed
- keep observer behavior unchanged by continuing to emit full path snapshots when the observer hook is present
- add a regression test that instruments array iteration to prove the no-observer hot path no longer pays observer-only path costs
- add a patch changeset for release notes

## Why
Issue #127 identified avoidable GC pressure in `materialize(...)`. The traversal always built fresh `childPath` arrays for every visited child even though those paths are only consumed by the optional test observer.

## Root Cause
`materialize` unconditionally expanded `frame.path` into a new array for each object entry and sequence element before calling `observer?.(...)`. When no observer was installed, the path clone work was still happening on several hot paths.

## Impact
- reduces allocation pressure for `materialize` when called from `toJson`, diff generation, patch compilation, and other internal helpers
- preserves the existing test observer contract when the hook is enabled
- adds regression coverage around this specific allocation trap

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test`

Closes #127