### PR TITLE
[codex] deprecate docFromJsonWithDot internals helper

### DIFF
--- a/.changeset/issue-129-doc-from-json-with-dot.md
+++ b/.changeset/issue-129-doc-from-json-with-dot.md
@@ -1,0 +1,7 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Deprecate `docFromJsonWithDot(...)` on the `./internals` surface and document why
+production callers should prefer `docFromJson(value, nextDot)` for unique causal
+metadata.

--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ Advanced/internal helpers are available from:
 import { crdtToJsonPatch, applyPatchAsActor } from "json-patch-to-crdt/internals";
 ```
 
+`docFromJsonWithDot(...)` remains available on `./internals` as a deprecated legacy
+fixture helper. It reuses a single seed dot across object nodes and synthesizes
+array child counters from that seed, so production code should prefer
+`docFromJson(value, nextDot)`.
+
 ## Notes
 
 - Arrays use a CRDT sequence internally; concurrent inserts are preserved.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -52,8 +52,15 @@ export function docFromJson(value: JsonValue, nextDot: () => Dot): Doc {
 }
 
 /**
- * Legacy: create a doc using a single dot with counter offsets for array children.
- * Prefer `docFromJson(value, nextDot)` to ensure unique dots per node.
+ * Legacy helper for tests and fixtures that seeds an entire document from one dot.
+ *
+ * It reuses that dot for object entries and synthesizes array child counters from the
+ * same seed, which can produce low-quality causal metadata and unrealistic sequence
+ * identities in production CRDT state.
+ *
+ * Prefer `docFromJson(value, nextDot)` so every node receives a fresh unique dot.
+ *
+ * @deprecated Use `docFromJson(value, nextDot)` for production documents.
  */
 export function docFromJsonWithDot(value: JsonValue, dot: Dot): Doc {
   return { root: deepNodeFromJson(value, dot) };

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -17,6 +17,7 @@ export {
 } from "./clock";
 
 // Advanced document/intent helpers.
+// `docFromJsonWithDot` is a deprecated legacy fixture helper that reuses causal metadata.
 export {
   docFromJson,
   docFromJsonWithDot,

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -1326,6 +1326,30 @@ describe("materialize", () => {
     expect(materialize(doc.root)).toEqual(value);
   });
 
+  it("assigns unique object dots with docFromJson and reuses dots with the legacy helper", () => {
+    const value: JsonValue = { left: { nested: 1 }, right: { nested: 2 } };
+    const generated = docFromJson(value, newDotGen("A", 0));
+    const legacy = docFromJsonWithDot(value, dot("A", 1));
+
+    if (generated.root.kind !== "obj" || legacy.root.kind !== "obj") {
+      throw new Error("Expected object roots");
+    }
+
+    const generatedLeft = generated.root.entries.get("left");
+    const generatedRight = generated.root.entries.get("right");
+    const legacyLeft = legacy.root.entries.get("left");
+    const legacyRight = legacy.root.entries.get("right");
+
+    expect(generatedLeft).toBeDefined();
+    expect(generatedRight).toBeDefined();
+    expect(legacyLeft).toBeDefined();
+    expect(legacyRight).toBeDefined();
+
+    expect(generatedLeft?.dot).not.toEqual(generatedRight?.dot);
+    expect(legacyLeft?.dot).toEqual(dot("A", 1));
+    expect(legacyRight?.dot).toEqual(dot("A", 1));
+  });
+
   it("materializes deeply nested object nodes", () => {
     const depth = 8_000;
     const root = makeDeepObjectNode(depth, "leaf");


### PR DESCRIPTION
## Summary
- deprecate `docFromJsonWithDot(...)` on the `json-patch-to-crdt/internals` surface
- explain in the source and README that it reuses a single seed dot for object entries and synthesizes array child counters from that seed
- add a regression test showing the legacy helper reuses object dots while `docFromJson(value, nextDot)` assigns distinct dots
- include a patch changeset for the release

## Why
Issue #129 calls out that `docFromJsonWithDot(...)` is still reachable from the internals surface even though its implementation notes already acknowledge that the synthetic dot pattern is not suitable for production causal metadata.

Marking the helper as deprecated and documenting the specific risk makes the safer API the obvious default without breaking existing fixture-oriented tests that still rely on the helper.

Closes #129.

## Impact
Advanced consumers using `./internals` will now see an explicit deprecation signal in editor/type tooling and stronger documentation telling them to prefer `docFromJson(value, nextDot)` for production documents.

Behavior is otherwise unchanged.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run test`