### PR TITLE
feat: add configurable unrelatedArrays merge strategy

### DIFF
--- a/.changeset/issue-130-unrelated-arrays-strategy.md
+++ b/.changeset/issue-130-unrelated-arrays-strategy.md
@@ -1,0 +1,21 @@
+---
+"json-patch-to-crdt": minor
+---
+
+Add configurable `unrelatedArrays` merge strategy for non-overlapping array sequences.
+
+The existing `requireSharedOrigin` boolean was too coarse for real integrations: callers had
+to choose between rejecting all unrelated arrays or accepting the current unsafe-union semantics.
+
+This change introduces an explicit `UnrelatedArraysStrategy` type with three values:
+
+- `"reject"` – abort the merge with a `LINEAGE_MISMATCH` error (the default, identical to `requireSharedOrigin: true`)
+- `"atomic-replace"` – replace the losing array entirely with the one that has the higher representative dot (causal last-write-wins at the array level), keeping merge results deterministic across peers
+- `"unsafe-union"` – union all elements without a lineage check (equivalent to the old `requireSharedOrigin: false`)
+
+The new option is available on both `MergeDocOptions` and `MergeStateOptions`. When `unrelatedArrays`
+is set it takes precedence over the now-deprecated `requireSharedOrigin` boolean, which is kept for
+backwards compatibility.
+
+The `atomic-replace` strategy is applied recursively at each array node in the document tree, so
+nested unrelated arrays inside objects are also handled correctly.

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type {
   JsonPrimitive,
   JsonValue,
   MergeStateOptions,
+  UnrelatedArraysStrategy,
   PatchErrorReason,
   PatchSemantics,
   SerializedState,

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -72,6 +72,7 @@ export type {
   JsonPatchToCrdtOptions,
   LwwReg,
   MergeDocOptions,
+  UnrelatedArraysStrategy,
   Node,
   ObjEntry,
   ObjNode,

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -136,7 +136,7 @@ export function tryMergeDoc(a: Doc, b: Doc, options: MergeDocOptions = {}): TryM
  * The merged clock keeps a stable actor identity:
  * - defaults to the actor from the first argument (`a`)
  * - can be overridden via `options.actor`
- * - optional `options.requireSharedOrigin` controls merge lineage checks
+ * - optional `options.unrelatedArrays` controls the merge strategy for non-overlapping sequences
  *
  * The merged counter is lifted to the highest counter already observed for
  * that actor across both input clocks and the merged document dots.

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -14,6 +14,7 @@ import type {
   RgaSeq,
   TryMergeDocResult,
   TryMergeStateResult,
+  UnrelatedArraysStrategy,
 } from "./types";
 
 import { createClock } from "./clock";
@@ -39,6 +40,11 @@ type MergeNodeResult = {
 type MergeDocResult = {
   doc: Doc;
   maxObservedCtr: number;
+};
+
+type MergeConfig = {
+  actor?: ActorId;
+  unrelatedArrays: UnrelatedArraysStrategy;
 };
 
 /** Error thrown by throwing merge helpers (`mergeDoc` / `mergeState`). */
@@ -81,22 +87,27 @@ export function mergeDoc(a: Doc, b: Doc, options: MergeDocOptions = {}): Doc {
 /** Non-throwing `mergeDoc` variant with structured conflict details. */
 export function tryMergeDoc(a: Doc, b: Doc, options: MergeDocOptions = {}): TryMergeDocResult {
   try {
-    const requireSharedOrigin = options.requireSharedOrigin ?? true;
-    const mismatchPath = requireSharedOrigin ? findSeqLineageMismatch(a.root, b.root, []) : null;
-    if (mismatchPath !== null) {
-      return {
-        ok: false,
-        error: {
+    const config: MergeConfig = {
+      unrelatedArrays: resolveUnrelatedArraysStrategy(options),
+    };
+
+    if (config.unrelatedArrays === "reject") {
+      const mismatchPath = findSeqLineageMismatch(a.root, b.root, []);
+      if (mismatchPath !== null) {
+        return {
           ok: false,
-          code: 409,
-          reason: "LINEAGE_MISMATCH",
-          message: `merge requires shared array origin at ${mismatchPath}`,
-          path: mismatchPath,
-        },
-      };
+          error: {
+            ok: false,
+            code: 409,
+            reason: "LINEAGE_MISMATCH",
+            message: `merge requires shared array origin at ${mismatchPath}`,
+            path: mismatchPath,
+          },
+        };
+      }
     }
 
-    return { ok: true, doc: mergeDocRoot(a.root, b.root).doc };
+    return { ok: true, doc: mergeDocRoot(a.root, b.root, config).doc };
   } catch (error) {
     if (error instanceof SharedElementMetadataMismatchError) {
       return {
@@ -146,25 +157,29 @@ export function tryMergeState(
   options: MergeStateOptions = {},
 ): TryMergeStateResult {
   try {
-    const requireSharedOrigin = options.requireSharedOrigin ?? true;
-    const mismatchPath = requireSharedOrigin
-      ? findSeqLineageMismatch(a.doc.root, b.doc.root, [])
-      : null;
-    if (mismatchPath !== null) {
-      return {
-        ok: false,
-        error: {
+    const actor = options.actor ?? a.clock.actor;
+    const config: MergeConfig = {
+      actor,
+      unrelatedArrays: resolveUnrelatedArraysStrategy(options),
+    };
+
+    if (config.unrelatedArrays === "reject") {
+      const mismatchPath = findSeqLineageMismatch(a.doc.root, b.doc.root, []);
+      if (mismatchPath !== null) {
+        return {
           ok: false,
-          code: 409,
-          reason: "LINEAGE_MISMATCH",
-          message: `merge requires shared array origin at ${mismatchPath}`,
-          path: mismatchPath,
-        },
-      };
+          error: {
+            ok: false,
+            code: 409,
+            reason: "LINEAGE_MISMATCH",
+            message: `merge requires shared array origin at ${mismatchPath}`,
+            path: mismatchPath,
+          },
+        };
+      }
     }
 
-    const actor = options.actor ?? a.clock.actor;
-    const merged = mergeDocRoot(a.doc.root, b.doc.root, actor);
+    const merged = mergeDocRoot(a.doc.root, b.doc.root, config);
     const ctr = maxObservedCtrForActor(merged.maxObservedCtr, actor, a, b);
     return { ok: true, state: { doc: merged.doc, clock: createClock(actor, ctr) } };
   } catch (error) {
@@ -237,9 +252,17 @@ function findSeqLineageMismatch(a: Node, b: Node, path: string[]): string | null
   return null;
 }
 
-function mergeDocRoot(a: Node, b: Node, actor?: ActorId): MergeDocResult {
-  const merged = mergeNodeAtDepth(a, b, 0, [], actor);
+function mergeDocRoot(a: Node, b: Node, config: MergeConfig): MergeDocResult {
+  const merged = mergeNodeAtDepth(a, b, 0, [], config);
   return { doc: { root: merged.node }, maxObservedCtr: merged.maxObservedCtr };
+}
+
+function resolveUnrelatedArraysStrategy(
+  options: MergeDocOptions | MergeStateOptions,
+): UnrelatedArraysStrategy {
+  if (options.unrelatedArrays !== undefined) return options.unrelatedArrays;
+  if (options.requireSharedOrigin === false) return "unsafe-union";
+  return "reject";
 }
 
 function maxObservedCtrForActor(
@@ -313,19 +336,19 @@ function mergeNodeAtDepth(
   b: Node,
   depth: number,
   path: string[],
-  actor?: ActorId,
+  config: MergeConfig,
 ): MergeNodeResult {
   assertTraversalDepth(depth);
 
   // Same kind → merge semantics
-  if (a.kind === "lww" && b.kind === "lww") return mergeLww(a, b, actor);
-  if (a.kind === "obj" && b.kind === "obj") return mergeObj(a, b, depth + 1, path, actor);
-  if (a.kind === "seq" && b.kind === "seq") return mergeSeq(a, b, depth + 1, path, actor);
+  if (a.kind === "lww" && b.kind === "lww") return mergeLww(a, b, config.actor);
+  if (a.kind === "obj" && b.kind === "obj") return mergeObj(a, b, depth + 1, path, config);
+  if (a.kind === "seq" && b.kind === "seq") return mergeSeq(a, b, depth + 1, path, config);
 
   // Kind mismatch: higher representative dot wins entirely.
   const cmp = compareDot(repDot(a), repDot(b));
-  if (cmp >= 0) return cloneNodeShallow(a, depth + 1, actor);
-  return cloneNodeShallow(b, depth + 1, actor);
+  if (cmp >= 0) return cloneNodeShallow(a, depth + 1, config.actor);
+  return cloneNodeShallow(b, depth + 1, config.actor);
 }
 
 function mergeLww(a: LwwReg, b: LwwReg, actor?: ActorId): MergeNodeResult {
@@ -346,7 +369,7 @@ function mergeObj(
   b: ObjNode,
   depth: number,
   path: string[],
-  actor?: ActorId,
+  config: MergeConfig,
 ): MergeNodeResult {
   assertTraversalDepth(depth);
   const entries = new Map<string, { node: Node; dot: Dot }>();
@@ -361,13 +384,13 @@ function mergeObj(
     if (da && db) {
       const mergedDot = compareDot(da, db) >= 0 ? { ...da } : { ...db };
       tombstone.set(key, mergedDot);
-      maxObservedCtr = Math.max(maxObservedCtr, maxObservedCtrForDot(mergedDot, actor));
+      maxObservedCtr = Math.max(maxObservedCtr, maxObservedCtrForDot(mergedDot, config.actor));
     } else if (da) {
       tombstone.set(key, { ...da });
-      maxObservedCtr = Math.max(maxObservedCtr, maxObservedCtrForDot(da, actor));
+      maxObservedCtr = Math.max(maxObservedCtr, maxObservedCtrForDot(da, config.actor));
     } else {
       tombstone.set(key, { ...db! });
-      maxObservedCtr = Math.max(maxObservedCtr, maxObservedCtrForDot(db!, actor));
+      maxObservedCtr = Math.max(maxObservedCtr, maxObservedCtrForDot(db!, config.actor));
     }
   }
 
@@ -380,16 +403,16 @@ function mergeObj(
     let merged: { node: Node; dot: Dot };
     let mergedNodeMaxObservedCtr = 0;
     if (ea && eb) {
-      const mergedNode = mergeNodeAtDepth(ea.node, eb.node, depth + 1, [...path, key], actor);
+      const mergedNode = mergeNodeAtDepth(ea.node, eb.node, depth + 1, [...path, key], config);
       const dot = compareDot(ea.dot, eb.dot) >= 0 ? { ...ea.dot } : { ...eb.dot };
       merged = { node: mergedNode.node, dot };
       mergedNodeMaxObservedCtr = mergedNode.maxObservedCtr;
     } else if (ea) {
-      const cloned = cloneNodeShallow(ea.node, depth + 1, actor);
+      const cloned = cloneNodeShallow(ea.node, depth + 1, config.actor);
       merged = { node: cloned.node, dot: { ...ea.dot } };
       mergedNodeMaxObservedCtr = cloned.maxObservedCtr;
     } else {
-      const cloned = cloneNodeShallow(eb!.node, depth + 1, actor);
+      const cloned = cloneNodeShallow(eb!.node, depth + 1, config.actor);
       merged = { node: cloned.node, dot: { ...eb!.dot } };
       mergedNodeMaxObservedCtr = cloned.maxObservedCtr;
     }
@@ -404,7 +427,7 @@ function mergeObj(
     maxObservedCtr = Math.max(
       maxObservedCtr,
       mergedNodeMaxObservedCtr,
-      maxObservedCtrForDot(merged.dot, actor),
+      maxObservedCtrForDot(merged.dot, config.actor),
     );
   }
 
@@ -416,9 +439,26 @@ function mergeSeq(
   b: RgaSeq,
   depth: number,
   path: string[],
-  actor?: ActorId,
+  config: MergeConfig,
 ): MergeNodeResult {
   assertTraversalDepth(depth);
+
+  // Atomic-replace: when both seqs are non-empty and share no element IDs,
+  // the one with the higher representative dot wins entirely.
+  if (config.unrelatedArrays === "atomic-replace" && a.elems.size > 0 && b.elems.size > 0) {
+    let shared = false;
+    for (const id of a.elems.keys()) {
+      if (b.elems.has(id)) {
+        shared = true;
+        break;
+      }
+    }
+    if (!shared) {
+      const winner = compareDot(repDot(a), repDot(b)) >= 0 ? a : b;
+      return cloneNodeShallow(winner, depth, config.actor);
+    }
+  }
+
   const elems = new Map<string, RgaElem>();
   let maxObservedCtr = 0;
 
@@ -441,7 +481,7 @@ function mergeSeq(
       // - tombstone: true if either side tombstoned it
       // - value: recursively merge child nodes
       // - prev/insDot are validated to match before merge
-      const mergedValue = mergeNodeAtDepth(ea.value, eb.value, depth + 1, [...path, id], actor);
+      const mergedValue = mergeNodeAtDepth(ea.value, eb.value, depth + 1, [...path, id], config);
       const mergedDeleteDot = mergeDeleteDot(ea.delDot, eb.delDot);
       elems.set(id, {
         id,
@@ -454,15 +494,15 @@ function mergeSeq(
       maxObservedCtr = Math.max(
         maxObservedCtr,
         mergedValue.maxObservedCtr,
-        maxObservedCtrForDot(ea.insDot, actor),
-        maxObservedCtrForDot(mergedDeleteDot, actor),
+        maxObservedCtrForDot(ea.insDot, config.actor),
+        maxObservedCtrForDot(mergedDeleteDot, config.actor),
       );
     } else if (ea) {
-      const cloned = cloneElem(ea, depth + 1, actor);
+      const cloned = cloneElem(ea, depth + 1, config.actor);
       elems.set(id, cloned.elem);
       maxObservedCtr = Math.max(maxObservedCtr, cloned.maxObservedCtr);
     } else {
-      const cloned = cloneElem(eb!, depth + 1, actor);
+      const cloned = cloneElem(eb!, depth + 1, config.actor);
       elems.set(id, cloned.elem);
       maxObservedCtr = Math.max(maxObservedCtr, cloned.maxObservedCtr);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,6 +331,17 @@ export type TryApplyPatchInPlaceResult = { ok: true } | { ok: false; error: Appl
 /** Non-throwing result for patch validation preflight. */
 export type ValidatePatchResult = { ok: true } | { ok: false; error: ApplyError };
 
+/**
+ * Merge strategy applied when two non-empty array sequences share no element lineage.
+ *
+ * - `"reject"` – abort the merge and return a `LINEAGE_MISMATCH` error (default).
+ * - `"atomic-replace"` – replace the losing array entirely with the one that has
+ *   the higher representative dot (causal last-write-wins at the array level).
+ * - `"unsafe-union"` – union all elements from both sequences without any lineage
+ *   check. Element ordering may be non-deterministic across peers.
+ */
+export type UnrelatedArraysStrategy = "reject" | "atomic-replace" | "unsafe-union";
+
 /** Options for `mergeState`. */
 export type MergeStateOptions = {
   /**
@@ -339,8 +350,15 @@ export type MergeStateOptions = {
    */
   actor?: ActorId;
   /**
-   * Require array sequences to share element lineage before merging.
-   * Defaults to `true`.
+   * Strategy for merging unrelated (non-overlapping) non-empty array sequences.
+   * Defaults to `"reject"`.
+   */
+  unrelatedArrays?: UnrelatedArraysStrategy;
+  /**
+   * @deprecated Use `unrelatedArrays` instead.
+   * When `true`, behaves like `unrelatedArrays: "reject"`.
+   * When `false`, behaves like `unrelatedArrays: "unsafe-union"`.
+   * Ignored when `unrelatedArrays` is also provided.
    */
   requireSharedOrigin?: boolean;
 };
@@ -348,8 +366,15 @@ export type MergeStateOptions = {
 /** Options for `mergeDoc`. */
 export type MergeDocOptions = {
   /**
-   * Require array sequences to share element lineage before merging.
-   * Defaults to `true`.
+   * Strategy for merging unrelated (non-overlapping) non-empty array sequences.
+   * Defaults to `"reject"`.
+   */
+  unrelatedArrays?: UnrelatedArraysStrategy;
+  /**
+   * @deprecated Use `unrelatedArrays` instead.
+   * When `true`, behaves like `unrelatedArrays: "reject"`.
+   * When `false`, behaves like `unrelatedArrays: "unsafe-union"`.
+   * Ignored when `unrelatedArrays` is also provided.
    */
   requireSharedOrigin?: boolean;
 };

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -352,6 +352,79 @@ describe("mergeDoc", () => {
     expect(materialize(merged.root)).toEqual([1, 1]);
   });
 
+  it("unsafe-union unions all elements from unrelated arrays", () => {
+    const a = docFromJson([1, 2], newDotGen("A"));
+    const b = docFromJson([3, 4], newDotGen("B"));
+    const merged = mergeDoc(a, b, { unrelatedArrays: "unsafe-union" });
+    const result = materialize(merged.root) as number[];
+    expect(result).toHaveLength(4);
+    expect(result.sort((x, y) => x - y)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("atomic-replace picks the causally newer unrelated array", () => {
+    const genA = newDotGen("A");
+    const genB = newDotGen("B");
+    // B gets a higher counter by consuming more dots
+    const a = docFromJson([1, 2], genA);
+    const b = docFromJson([3, 4, 5], genB);
+    const mergedAB = mergeDoc(a, b, { unrelatedArrays: "atomic-replace" });
+    const mergedBA = mergeDoc(b, a, { unrelatedArrays: "atomic-replace" });
+    // Both directions should agree — the winner is deterministic
+    expect(materialize(mergedAB.root)).toEqual(materialize(mergedBA.root));
+  });
+
+  it("atomic-replace keeps the array with the highest representative dot", () => {
+    // A is created first, then B is created independently with more elements
+    // so B's highest dot counter will be higher
+    const genA = newDotGen("A");
+    const a = docFromJson([99], genA);
+    const genB = newDotGen("B");
+    // burn dots on B so its rep dot is definitively higher
+    genB();
+    genB();
+    genB();
+    const b = docFromJson([1, 2], genB);
+    const merged = mergeDoc(a, b, { unrelatedArrays: "atomic-replace" });
+    expect(materialize(merged.root)).toEqual([1, 2]);
+  });
+
+  it("atomic-replace falls through to normal merge when arrays share elements", () => {
+    const origin = docFromJson([1, 2], newDotGen("origin"));
+    const a = cloneDoc(origin);
+    const b = cloneDoc(origin);
+    // Both still share elements — normal merge should apply
+    const merged = mergeDoc(a, b, { unrelatedArrays: "atomic-replace" });
+    expect(materialize(merged.root)).toEqual([1, 2]);
+  });
+
+  it("atomic-replace works for nested unrelated arrays inside an object", () => {
+    const genA = newDotGen("A");
+    const genB = newDotGen("B");
+    const a = docFromJson({ items: [10, 20] }, genA);
+    const b = docFromJson({ items: [30, 40, 50] }, genB);
+    const mergedAB = mergeDoc(a, b, { unrelatedArrays: "atomic-replace" });
+    const mergedBA = mergeDoc(b, a, { unrelatedArrays: "atomic-replace" });
+    expect(materialize(mergedAB.root)).toEqual(materialize(mergedBA.root));
+  });
+
+  it("reject strategy behaves identically to the default", () => {
+    const a = docFromJson([1], newDotGen("A"));
+    const b = docFromJson([1], newDotGen("B"));
+    expect(() => mergeDoc(a, b, { unrelatedArrays: "reject" })).toThrow(MergeError);
+    const res = tryMergeDoc(a, b, { unrelatedArrays: "reject" });
+    expect(res.ok).toBeFalse();
+    if (!res.ok) expect(res.error.reason).toBe("LINEAGE_MISMATCH");
+  });
+
+  it("unrelatedArrays option takes precedence over deprecated requireSharedOrigin", () => {
+    const a = docFromJson([1], newDotGen("A"));
+    const b = docFromJson([1], newDotGen("B"));
+    // unrelatedArrays: "unsafe-union" should win even though requireSharedOrigin: true
+    const merged = mergeDoc(a, b, { unrelatedArrays: "unsafe-union", requireSharedOrigin: true });
+    const result = materialize(merged.root) as number[];
+    expect(result).toHaveLength(2);
+  });
+
   it("rejects shared RGA ids when predecessor metadata disagrees", () => {
     const origin = createState({ list: ["a", "b"] }, { actor: "origin" });
     const a = cloneDoc(origin.doc);

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -362,15 +362,15 @@ describe("mergeDoc", () => {
   });
 
   it("atomic-replace picks the causally newer unrelated array", () => {
-    const genA = newDotGen("A");
-    const genB = newDotGen("B");
-    // B gets a higher counter by consuming more dots
-    const a = docFromJson([1, 2], genA);
-    const b = docFromJson([3, 4, 5], genB);
+    // a gets dots A:1, A:2 (repDot = A:2 → ctr 2)
+    // b gets dots B:1, B:2, B:3 (repDot = B:3 → ctr 3)
+    // B wins because ctr 3 > ctr 2
+    const a = docFromJson([1, 2], newDotGen("A"));
+    const b = docFromJson([3, 4, 5], newDotGen("B"));
     const mergedAB = mergeDoc(a, b, { unrelatedArrays: "atomic-replace" });
     const mergedBA = mergeDoc(b, a, { unrelatedArrays: "atomic-replace" });
-    // Both directions should agree — the winner is deterministic
-    expect(materialize(mergedAB.root)).toEqual(materialize(mergedBA.root));
+    expect(materialize(mergedAB.root)).toEqual([3, 4, 5]);
+    expect(materialize(mergedBA.root)).toEqual([3, 4, 5]);
   });
 
   it("atomic-replace keeps the array with the highest representative dot", () => {


### PR DESCRIPTION
Closes #130

## Summary

- Replaces the coarse `requireSharedOrigin: boolean` with an explicit `UnrelatedArraysStrategy` union type (`"reject" | "atomic-replace" | "unsafe-union"`) on both `MergeDocOptions` and `MergeStateOptions`
- Adds a new `"atomic-replace"` mode: when two non-empty arrays share no element IDs, the one with the higher representative dot wins entirely (causal LWW at the array level), applied recursively so nested arrays inside objects are handled correctly
- `"reject"` is the default (identical to `requireSharedOrigin: true`); `"unsafe-union"` is equivalent to `requireSharedOrigin: false`
- `requireSharedOrigin` is kept and marked `@deprecated`; `unrelatedArrays` takes precedence when both are set
- `UnrelatedArraysStrategy` is exported from the public index and the internals surface

## Test plan

- [ ] `unsafe-union` unions all elements from two unrelated arrays
- [ ] `atomic-replace` is deterministic (same result regardless of argument order)
- [ ] `atomic-replace` picks the array with the highest representative dot
- [ ] `atomic-replace` falls through to normal merge when arrays share elements
- [ ] `atomic-replace` handles nested unrelated arrays inside objects
- [ ] `reject` behaves identically to the default and returns `LINEAGE_MISMATCH`
- [ ] `unrelatedArrays` takes precedence over deprecated `requireSharedOrigin`
- [ ] All 344 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)