### PR TITLE
[codex] add resource budgets for untrusted patch, merge, diff, and deserialize inputs

### DIFF
--- a/.changeset/tough-dodos-rule.md
+++ b/.changeset/tough-dodos-rule.md
@@ -1,3 +1,4 @@
+---
 "json-patch-to-crdt": minor
 ---
 

--- a/.changeset/tough-dodos-rule.md
+++ b/.changeset/tough-dodos-rule.md
@@ -1,0 +1,8 @@
+"json-patch-to-crdt": minor
+---
+
+Add configurable resource budgets across patch, diff, merge, and deserialize APIs.
+
+This introduces shared resource-budget options and typed budget-exhaustion failures so
+callers handling untrusted input can cap patch program length, breadth-oriented object
+and sequence traversal, serialized payload inspection, and array diff work.

--- a/src/budget.ts
+++ b/src/budget.ts
@@ -1,0 +1,143 @@
+import type {
+  ApplyError,
+  DeserializeFailure,
+  ResourceBudget,
+  ResourceBudgetExceededFailure,
+  ResourceBudgetKind,
+} from "./types";
+
+function isNonNegativeSafeInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function formatPath(path?: string): string {
+  if (path === undefined || path === "") {
+    return "";
+  }
+
+  return ` at ${path}`;
+}
+
+function formatOpIndex(opIndex?: number): string {
+  if (opIndex === undefined) {
+    return "";
+  }
+
+  return ` at op ${opIndex}`;
+}
+
+export class ResourceBudgetError extends Error {
+  readonly reason = "RESOURCE_BUDGET_EXCEEDED" as const;
+  readonly code = 409 as const;
+  readonly budget: ResourceBudgetKind;
+  readonly limit: number;
+  readonly actual: number;
+  readonly path?: string;
+  readonly opIndex?: number;
+
+  constructor(
+    budget: ResourceBudgetKind,
+    limit: number,
+    actual: number,
+    path?: string,
+    opIndex?: number,
+  ) {
+    super(
+      `resource budget '${budget}' exceeded${formatPath(path)}${formatOpIndex(opIndex)}: ${actual} > ${limit}`,
+    );
+    this.name = "ResourceBudgetError";
+    this.budget = budget;
+    this.limit = limit;
+    this.actual = actual;
+    this.path = path;
+    this.opIndex = opIndex;
+  }
+}
+
+export class ResourceBudgetMeter {
+  readonly #budget: ResourceBudget;
+  readonly #counts: Record<ResourceBudgetKind, number>;
+
+  constructor(budget?: ResourceBudget) {
+    this.#budget = validateBudget(budget);
+    this.#counts = {
+      patchOperations: 0,
+      objectEntries: 0,
+      sequenceElements: 0,
+      visitedNodes: 0,
+      serializedElements: 0,
+      arrayDiffCells: 0,
+    };
+  }
+
+  count(kind: ResourceBudgetKind, delta: number, path?: string, opIndex?: number): void {
+    if (delta <= 0) {
+      return;
+    }
+
+    this.#counts[kind] += delta;
+    const limit = this.#budget[kind];
+    if (limit !== undefined && this.#counts[kind] > limit) {
+      throw new ResourceBudgetError(kind, limit, this.#counts[kind], path, opIndex);
+    }
+  }
+}
+
+export function createBudgetMeter(budget?: ResourceBudget): ResourceBudgetMeter | undefined {
+  if (budget === undefined) {
+    return undefined;
+  }
+
+  return new ResourceBudgetMeter(budget);
+}
+
+export function toBudgetApplyError(error: ResourceBudgetError): ApplyError {
+  return {
+    ok: false,
+    code: error.code,
+    reason: error.reason,
+    message: error.message,
+    budget: error.budget,
+    limit: error.limit,
+    actual: error.actual,
+    path: error.path,
+    opIndex: error.opIndex,
+  };
+}
+
+export function toBudgetDeserializeFailure(
+  error: ResourceBudgetError,
+): ResourceBudgetExceededFailure | DeserializeFailure {
+  return {
+    code: error.code,
+    reason: error.reason,
+    message: error.message,
+    budget: error.budget,
+    limit: error.limit,
+    actual: error.actual,
+    path: error.path,
+  };
+}
+
+function validateBudget(budget: ResourceBudget | undefined): ResourceBudget {
+  if (budget === undefined) {
+    return {};
+  }
+
+  const normalized: ResourceBudget = {};
+  const entries = Object.entries(budget) as Array<[ResourceBudgetKind, number | undefined]>;
+
+  for (const [key, value] of entries) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (!isNonNegativeSafeInteger(value)) {
+      throw new Error(`resource budget '${key}' must be a non-negative safe integer`);
+    }
+
+    normalized[key] = value;
+  }
+
+  return normalized;
+}

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -15,6 +15,7 @@ import type {
   RgaSeq,
 } from "./types";
 
+import { createBudgetMeter } from "./budget";
 import { TraversalDepthError, assertTraversalDepth, toDepthApplyError } from "./depth";
 import { compareDot, dotToElemId } from "./dot";
 import { materialize } from "./materialize";
@@ -1477,7 +1478,7 @@ function diffNodeToPatch(
  */
 export function crdtToJsonPatch(base: Doc, head: Doc, options?: DiffOptions): JsonPatchOp[] {
   // Preserve full-document runtime guardrail behavior for strict/normalize modes.
-  if ((options?.jsonValidation ?? "none") !== "none") {
+  if ((options?.jsonValidation ?? "none") !== "none" || options?.resourceBudget !== undefined) {
     return diffJsonPatch(materialize(base.root), materialize(head.root), options);
   }
 
@@ -1507,6 +1508,13 @@ export function crdtToFullReplace(doc: Doc): JsonPatchOp[] {
 function jsonPatchToCrdtInternal(options: JsonPatchToCrdtOptions): ApplyResult {
   const evalTestAgainst = options.evalTestAgainst ?? "head";
   const semantics = options.semantics ?? "sequential";
+  const budgetMeter = createBudgetMeter(options.resourceBudget);
+
+  try {
+    budgetMeter?.count("patchOperations", options.patch.length);
+  } catch (error) {
+    return toApplyError(error);
+  }
 
   if (semantics === "base") {
     const baseJson = materialize(options.base.root);
@@ -1514,6 +1522,7 @@ function jsonPatchToCrdtInternal(options: JsonPatchToCrdtOptions): ApplyResult {
     try {
       intents = compileJsonPatchToIntent(baseJson, options.patch, {
         semantics: "base",
+        resourceBudget: options.resourceBudget,
       });
     } catch (error) {
       return toApplyError(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,14 @@ export type {
   CrdtState,
   CompactStateTombstonesResult,
   DeserializeFailure,
+  DeserializeOptions,
   DiffOptions,
   DeserializeErrorReason,
   ForkStateOptions,
   JsonValidationMode,
+  ResourceBudget,
+  ResourceBudgetExceededFailure,
+  ResourceBudgetKind,
   JsonPatch,
   JsonPatchOp,
   JsonPrimitive,
@@ -47,6 +51,7 @@ export {
 
 export { JsonValueValidationError } from "./json-value";
 export { ClockValidationError } from "./clock";
+export { ResourceBudgetError } from "./budget";
 
 // JSON helpers
 export { diffJsonPatch } from "./patch";

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -41,6 +41,7 @@ export {
   jsonEquals,
   stableJsonValueKey,
 } from "./patch";
+export { ResourceBudgetError } from "./budget";
 
 // Node-level materialization helper.
 export { materialize } from "./materialize";
@@ -65,6 +66,7 @@ export type {
   CompactStateTombstonesResult,
   CompilePatchOptions,
   DeserializeFailure,
+  DeserializeOptions,
   Doc,
   Dot,
   ElemId,
@@ -78,6 +80,9 @@ export type {
   ObjNode,
   RgaElem,
   RgaSeq,
+  ResourceBudget,
+  ResourceBudgetExceededFailure,
+  ResourceBudgetKind,
   SerializedClock,
   SerializedDoc,
   SerializedNode,

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -487,11 +487,6 @@ function mergeSeq(
   // Atomic-replace: when both seqs are non-empty and share no element IDs,
   // the one with the higher representative dot wins entirely.
   if (config.unrelatedArrays === "atomic-replace" && a.elems.size > 0 && b.elems.size > 0) {
-    config.budgetMeter?.count(
-      "sequenceElements",
-      a.elems.size + b.elems.size,
-      stringifyJsonPointer(path),
-    );
     let shared = false;
     for (const id of a.elems.keys()) {
       if (b.elems.has(id)) {
@@ -500,6 +495,11 @@ function mergeSeq(
       }
     }
     if (!shared) {
+      config.budgetMeter?.count(
+        "sequenceElements",
+        a.elems.size + b.elems.size,
+        stringifyJsonPointer(path),
+      );
       const winner = compareDot(repDot(a), repDot(b)) >= 0 ? a : b;
       return cloneNodeShallow(winner, depth, config.actor);
     }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -12,11 +12,13 @@ import type {
   PatchErrorReason,
   RgaElem,
   RgaSeq,
+  ResourceBudgetKind,
   TryMergeDocResult,
   TryMergeStateResult,
   UnrelatedArraysStrategy,
 } from "./types";
 
+import { ResourceBudgetError, createBudgetMeter, toBudgetApplyError } from "./budget";
 import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth, toDepthApplyError } from "./depth";
 import { compareDot } from "./dot";
@@ -45,12 +47,16 @@ type MergeDocResult = {
 type MergeConfig = {
   actor?: ActorId;
   unrelatedArrays: UnrelatedArraysStrategy;
+  budgetMeter?: ReturnType<typeof createBudgetMeter>;
 };
 
 /** Error thrown by throwing merge helpers (`mergeDoc` / `mergeState`). */
 export class MergeError extends Error {
   readonly code: 409;
   readonly reason: PatchErrorReason;
+  readonly budget?: ResourceBudgetKind;
+  readonly limit?: number;
+  readonly actual?: number;
   readonly path?: string;
 
   constructor(error: ApplyError) {
@@ -58,6 +64,11 @@ export class MergeError extends Error {
     this.name = "MergeError";
     this.code = error.code;
     this.reason = error.reason;
+    if (error.reason === "RESOURCE_BUDGET_EXCEEDED") {
+      this.budget = error.budget;
+      this.limit = error.limit;
+      this.actual = error.actual;
+    }
     this.path = error.path;
   }
 }
@@ -89,10 +100,11 @@ export function tryMergeDoc(a: Doc, b: Doc, options: MergeDocOptions = {}): TryM
   try {
     const config: MergeConfig = {
       unrelatedArrays: resolveUnrelatedArraysStrategy(options),
+      budgetMeter: createBudgetMeter(options.resourceBudget),
     };
 
     if (config.unrelatedArrays === "reject") {
-      const mismatchPath = findSeqLineageMismatch(a.root, b.root, []);
+      const mismatchPath = findSeqLineageMismatch(a.root, b.root, [], config);
       if (mismatchPath !== null) {
         return {
           ok: false,
@@ -124,6 +136,10 @@ export function tryMergeDoc(a: Doc, b: Doc, options: MergeDocOptions = {}): TryM
 
     if (error instanceof TraversalDepthError) {
       return { ok: false, error: toDepthApplyError(error) };
+    }
+
+    if (error instanceof ResourceBudgetError) {
+      return { ok: false, error: toBudgetApplyError(error) };
     }
 
     throw error;
@@ -161,10 +177,11 @@ export function tryMergeState(
     const config: MergeConfig = {
       actor,
       unrelatedArrays: resolveUnrelatedArraysStrategy(options),
+      budgetMeter: createBudgetMeter(options.resourceBudget),
     };
 
     if (config.unrelatedArrays === "reject") {
-      const mismatchPath = findSeqLineageMismatch(a.doc.root, b.doc.root, []);
+      const mismatchPath = findSeqLineageMismatch(a.doc.root, b.doc.root, [], config);
       if (mismatchPath !== null) {
         return {
           ok: false,
@@ -200,11 +217,20 @@ export function tryMergeState(
       return { ok: false, error: toDepthApplyError(error) };
     }
 
+    if (error instanceof ResourceBudgetError) {
+      return { ok: false, error: toBudgetApplyError(error) };
+    }
+
     throw error;
   }
 }
 
-function findSeqLineageMismatch(a: Node, b: Node, path: string[]): string | null {
+function findSeqLineageMismatch(
+  a: Node,
+  b: Node,
+  path: string[],
+  config: MergeConfig,
+): string | null {
   const stack: Array<{ a: Node; b: Node; path: string[]; depth: number }> = [
     { a, b, path, depth: path.length },
   ];
@@ -212,8 +238,14 @@ function findSeqLineageMismatch(a: Node, b: Node, path: string[]): string | null
   while (stack.length > 0) {
     const frame = stack.pop()!;
     assertTraversalDepth(frame.depth);
+    config.budgetMeter?.count("visitedNodes", 1, stringifyJsonPointer(frame.path));
 
     if (frame.a.kind === "seq" && frame.b.kind === "seq") {
+      config.budgetMeter?.count(
+        "sequenceElements",
+        frame.a.elems.size + frame.b.elems.size,
+        stringifyJsonPointer(frame.path),
+      );
       const hasElemsA = frame.a.elems.size > 0;
       const hasElemsB = frame.b.elems.size > 0;
       if (hasElemsA && hasElemsB) {
@@ -235,6 +267,11 @@ function findSeqLineageMismatch(a: Node, b: Node, path: string[]): string | null
       const left = frame.a;
       const right = frame.b;
       const sharedKeys = [...left.entries.keys()].filter((key) => right.entries.has(key));
+      config.budgetMeter?.count(
+        "objectEntries",
+        sharedKeys.length,
+        stringifyJsonPointer(frame.path),
+      );
       for (let i = sharedKeys.length - 1; i >= 0; i--) {
         const key = sharedKeys[i]!;
         const nextA = left.entries.get(key)!.node;
@@ -339,6 +376,7 @@ function mergeNodeAtDepth(
   config: MergeConfig,
 ): MergeNodeResult {
   assertTraversalDepth(depth);
+  config.budgetMeter?.count("visitedNodes", 1, stringifyJsonPointer(path));
 
   // Same kind → merge semantics
   if (a.kind === "lww" && b.kind === "lww") return mergeLww(a, b, config.actor);
@@ -378,6 +416,7 @@ function mergeObj(
 
   // Merge tombstones: max dot per key.
   const allTombKeys = new Set([...a.tombstone.keys(), ...b.tombstone.keys()]);
+  config.budgetMeter?.count("objectEntries", allTombKeys.size, stringifyJsonPointer(path));
   for (const key of allTombKeys) {
     const da = a.tombstone.get(key);
     const db = b.tombstone.get(key);
@@ -396,6 +435,7 @@ function mergeObj(
 
   // Merge entries: union of keys, recursive merge when both present.
   const allKeys = new Set([...a.entries.keys(), ...b.entries.keys()]);
+  config.budgetMeter?.count("objectEntries", allKeys.size, stringifyJsonPointer(path));
   for (const key of allKeys) {
     const ea = a.entries.get(key);
     const eb = b.entries.get(key);
@@ -442,10 +482,16 @@ function mergeSeq(
   config: MergeConfig,
 ): MergeNodeResult {
   assertTraversalDepth(depth);
+  config.budgetMeter?.count("visitedNodes", 1, stringifyJsonPointer(path));
 
   // Atomic-replace: when both seqs are non-empty and share no element IDs,
   // the one with the higher representative dot wins entirely.
   if (config.unrelatedArrays === "atomic-replace" && a.elems.size > 0 && b.elems.size > 0) {
+    config.budgetMeter?.count(
+      "sequenceElements",
+      a.elems.size + b.elems.size,
+      stringifyJsonPointer(path),
+    );
     let shared = false;
     for (const id of a.elems.keys()) {
       if (b.elems.has(id)) {
@@ -464,6 +510,7 @@ function mergeSeq(
 
   // Union by element ID.
   const allIds = new Set([...a.elems.keys(), ...b.elems.keys()]);
+  config.budgetMeter?.count("sequenceElements", allIds.size, stringifyJsonPointer(path));
   for (const id of allIds) {
     const ea = a.elems.get(id);
     const eb = b.elems.get(id);

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -7,6 +7,7 @@ import type {
   PatchErrorReason,
 } from "./types";
 
+import { ResourceBudgetMeter, createBudgetMeter } from "./budget";
 import { assertTraversalDepth } from "./depth";
 import { coerceRuntimeJsonValue } from "./json-value";
 import { ROOT_KEY } from "./types";
@@ -27,6 +28,7 @@ type TrimmedArrayWindow = {
 type InternalCompilePatchOptions = {
   pointerCache?: Map<string, string[]>;
   opIndexOffset?: number;
+  budgetMeter?: ResourceBudgetMeter;
 };
 
 interface DiffValueFrame {
@@ -249,11 +251,13 @@ export function compileJsonPatchToIntent(
 ): IntentOp[] {
   // Internal session hints are threaded from state.ts via structural typing.
   const internalOptions = options as CompilePatchOptions & InternalCompilePatchOptions;
+  const budgetMeter = internalOptions.budgetMeter ?? createBudgetMeter(options.resourceBudget);
   const semantics = options.semantics ?? "sequential";
   const opIndexOffset = internalOptions.opIndexOffset ?? 0;
   let workingBase: JsonValue = baseJson;
   const pointerCache = internalOptions.pointerCache ?? new Map<string, string[]>();
   const intents: IntentOp[] = [];
+  budgetMeter?.count("patchOperations", patch.length);
 
   for (let opIndex = 0; opIndex < patch.length; opIndex++) {
     const op = patch[opIndex]!;
@@ -285,6 +289,8 @@ export function compileJsonPatchOpToIntent(
   const semantics = options.semantics ?? "sequential";
   const pointerCache = internalOptions.pointerCache ?? new Map<string, string[]>();
   const opIndex = internalOptions.opIndexOffset ?? 0;
+  const budgetMeter = internalOptions.budgetMeter ?? createBudgetMeter(options.resourceBudget);
+  budgetMeter?.count("patchOperations", 1, undefined, opIndex);
   return compileSingleOp(baseJson, op, opIndex, semantics, pointerCache);
 }
 
@@ -307,12 +313,13 @@ export function diffJsonPatch(
   next: JsonValue,
   options: DiffOptions = {},
 ): JsonPatchOp[] {
+  const budgetMeter = createBudgetMeter(options.resourceBudget);
   const runtimeMode = options.jsonValidation ?? "none";
   const runtimeBase = coerceRuntimeJsonValue(base, runtimeMode);
   const runtimeNext = coerceRuntimeJsonValue(next, runtimeMode);
   const ops: JsonPatchOp[] = [];
   const path: string[] = [];
-  diffValue(path, runtimeBase, runtimeNext, ops, options);
+  diffValue(path, runtimeBase, runtimeNext, ops, options, budgetMeter);
   return ops;
 }
 
@@ -322,6 +329,7 @@ function diffValue(
   next: JsonValue,
   ops: JsonPatchOp[],
   options: DiffOptions,
+  budgetMeter?: ResourceBudgetMeter,
 ): void {
   const stack: DiffFrame[] = [{ kind: "value", base, next }];
 
@@ -357,6 +365,7 @@ function diffValue(
     }
 
     assertTraversalDepth(path.length);
+    budgetMeter?.count("visitedNodes", 1, stringifyJsonPointer(path));
 
     if (frame.base === frame.next) {
       continue;
@@ -377,14 +386,14 @@ function diffValue(
       const arrayStrategy = options.arrayStrategy ?? "lcs";
 
       if (arrayStrategy === "lcs") {
-        if (!diffArrayWithLcsMatrix(path, frame.base, frame.next, ops, options)) {
+        if (!diffArrayWithLcsMatrix(path, frame.base, frame.next, ops, options, budgetMeter)) {
           ops.push({ op: "replace", path: stringifyJsonPointer(path), value: frame.next });
         }
         continue;
       }
 
       if (arrayStrategy === "lcs-linear") {
-        if (!diffArrayWithLinearLcs(path, frame.base, frame.next, ops, options)) {
+        if (!diffArrayWithLinearLcs(path, frame.base, frame.next, ops, options, budgetMeter)) {
           ops.push({ op: "replace", path: stringifyJsonPointer(path), value: frame.next });
         }
         continue;
@@ -402,6 +411,11 @@ function diffValue(
     }
 
     const { sharedKeys, baseOnlyKeys, nextOnlyKeys } = collectObjectKeys(frame.base, frame.next);
+    budgetMeter?.count(
+      "objectEntries",
+      sharedKeys.length + baseOnlyKeys.length + nextOnlyKeys.length,
+      stringifyJsonPointer(path),
+    );
     const hasStructuralChanges = baseOnlyKeys.length > 0 || nextOnlyKeys.length > 0;
     if (
       !hasStructuralChanges &&
@@ -639,12 +653,15 @@ function diffArrayWithLcsMatrix(
   next: JsonValue[],
   ops: JsonPatchOp[],
   options: DiffOptions,
+  budgetMeter?: ResourceBudgetMeter,
 ): boolean {
   const window = trimEqualArrayEdges(base, next);
   const baseStart = window.baseStart;
   const nextStart = window.nextStart;
   const n = window.unmatchedBaseLength;
   const m = window.unmatchedNextLength;
+  budgetMeter?.count("sequenceElements", n + m, stringifyJsonPointer(path));
+  budgetMeter?.count("arrayDiffCells", (n + 1) * (m + 1), stringifyJsonPointer(path));
 
   if (!shouldUseLcsDiff(n, m, options.lcsMaxCells)) {
     return false;
@@ -674,8 +691,19 @@ function diffArrayWithLinearLcs(
   next: JsonValue[],
   ops: JsonPatchOp[],
   options: DiffOptions,
+  budgetMeter?: ResourceBudgetMeter,
 ): boolean {
   const window = trimEqualArrayEdges(base, next);
+  budgetMeter?.count(
+    "sequenceElements",
+    window.unmatchedBaseLength + window.unmatchedNextLength,
+    stringifyJsonPointer(path),
+  );
+  budgetMeter?.count(
+    "arrayDiffCells",
+    (window.unmatchedBaseLength + 1) * (window.unmatchedNextLength + 1),
+    stringifyJsonPointer(path),
+  );
   if (!shouldUseLinearLcsDiff(window.unmatchedBaseLength, window.unmatchedNextLength, options)) {
     return false;
   }

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -661,11 +661,12 @@ function diffArrayWithLcsMatrix(
   const n = window.unmatchedBaseLength;
   const m = window.unmatchedNextLength;
   budgetMeter?.count("sequenceElements", n + m, stringifyJsonPointer(path));
-  budgetMeter?.count("arrayDiffCells", (n + 1) * (m + 1), stringifyJsonPointer(path));
 
   if (!shouldUseLcsDiff(n, m, options.lcsMaxCells)) {
     return false;
   }
+
+  budgetMeter?.count("arrayDiffCells", (n + 1) * (m + 1), stringifyJsonPointer(path));
 
   if (n === 0 && m === 0) {
     return true;
@@ -699,14 +700,14 @@ function diffArrayWithLinearLcs(
     window.unmatchedBaseLength + window.unmatchedNextLength,
     stringifyJsonPointer(path),
   );
+  if (!shouldUseLinearLcsDiff(window.unmatchedBaseLength, window.unmatchedNextLength, options)) {
+    return false;
+  }
   budgetMeter?.count(
     "arrayDiffCells",
     (window.unmatchedBaseLength + 1) * (window.unmatchedNextLength + 1),
     stringifyJsonPointer(path),
   );
-  if (!shouldUseLinearLcsDiff(window.unmatchedBaseLength, window.unmatchedNextLength, options)) {
-    return false;
-  }
 
   const steps: ArrayDiffStep[] = [];
   buildArrayEditScriptLinearSpace(

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,6 +1,7 @@
 import type {
   CrdtState,
   DeserializeFailure,
+  DeserializeOptions,
   Doc,
   DeserializeErrorReason,
   Dot,
@@ -15,6 +16,12 @@ import type {
   TryDeserializeStateResult,
 } from "./types";
 
+import {
+  ResourceBudgetError,
+  ResourceBudgetMeter,
+  createBudgetMeter,
+  toBudgetDeserializeFailure,
+} from "./budget";
 import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth } from "./depth";
 import { dotToElemId } from "./dot";
@@ -59,20 +66,28 @@ export function serializeDoc(doc: Doc): SerializedDoc {
 }
 
 /** Reconstruct a CRDT document from its serialized form. */
-export function deserializeDoc(data: SerializedDoc): Doc {
+export function deserializeDoc(data: SerializedDoc, options: DeserializeOptions = {}): Doc {
+  const budgetMeter = createBudgetMeter(options.resourceBudget);
+  return deserializeDocInternal(data, budgetMeter);
+}
+
+function deserializeDocInternal(data: SerializedDoc, budgetMeter?: ResourceBudgetMeter): Doc {
   const raw = readSerializedDocEnvelope(data);
 
   if (!("root" in raw)) {
     fail("INVALID_SERIALIZED_SHAPE", "/root", "serialized doc is missing root");
   }
 
-  return { root: deserializeNode(raw.root, "/root", 0) };
+  return { root: deserializeNode(raw.root, "/root", 0, budgetMeter) };
 }
 
 /** Non-throwing `deserializeDoc` variant with typed validation details. */
-export function tryDeserializeDoc(data: SerializedDoc): TryDeserializeDocResult {
+export function tryDeserializeDoc(
+  data: SerializedDoc,
+  options: DeserializeOptions = {},
+): TryDeserializeDocResult {
   try {
-    return { ok: true, doc: deserializeDoc(data) };
+    return { ok: true, doc: deserializeDoc(data, options) };
   } catch (error) {
     const deserializeError = toDeserializeFailure(error);
     if (deserializeError) {
@@ -98,8 +113,12 @@ export function serializeState(state: CrdtState): SerializedState {
  * May throw `TraversalDepthError` when the payload exceeds the maximum
  * supported nesting depth.
  */
-export function deserializeState(data: SerializedState): CrdtState {
+export function deserializeState(
+  data: SerializedState,
+  options: DeserializeOptions = {},
+): CrdtState {
   const raw = readSerializedStateEnvelope(data);
+  const budgetMeter = createBudgetMeter(options.resourceBudget);
 
   if (!("doc" in raw)) {
     fail("INVALID_SERIALIZED_SHAPE", "/doc", "serialized state is missing doc");
@@ -112,16 +131,19 @@ export function deserializeState(data: SerializedState): CrdtState {
   const clockRaw = asRecord(raw.clock, "/clock");
   const actor = readActor(clockRaw.actor, "/clock/actor");
   const ctr = readCounter(clockRaw.ctr, "/clock/ctr");
-  const doc = deserializeDoc(raw.doc as SerializedDoc);
+  const doc = deserializeDocInternal(raw.doc as SerializedDoc, budgetMeter);
   const observedCtr = observedVersionVector(doc)[actor] ?? 0;
   const clock = createClock(actor, Math.max(ctr, observedCtr));
   return { doc, clock };
 }
 
 /** Non-throwing `deserializeState` variant with typed validation details. */
-export function tryDeserializeState(data: SerializedState): TryDeserializeStateResult {
+export function tryDeserializeState(
+  data: SerializedState,
+  options: DeserializeOptions = {},
+): TryDeserializeStateResult {
   try {
-    return { ok: true, state: deserializeState(data) };
+    return { ok: true, state: deserializeState(data, options) };
   } catch (error) {
     const deserializeError = toDeserializeFailure(error);
     if (deserializeError) {
@@ -189,8 +211,14 @@ function readSerializedStateEnvelope(data: SerializedState): Record<string, unkn
   return raw;
 }
 
-function deserializeNode(node: unknown, path: string, depth: number): Node {
+function deserializeNode(
+  node: unknown,
+  path: string,
+  depth: number,
+  budgetMeter?: ResourceBudgetMeter,
+): Node {
   assertTraversalDepth(depth);
+  budgetMeter?.count("visitedNodes", 1, path);
   const raw = asRecord(node, path);
   const kind = readString(raw.kind, `${path}/kind`);
 
@@ -204,7 +232,7 @@ function deserializeNode(node: unknown, path: string, depth: number): Node {
 
     return {
       kind: "lww",
-      value: structuredClone(readJsonValue(raw.value, `${path}/value`, depth + 1)),
+      value: structuredClone(readJsonValue(raw.value, `${path}/value`, depth + 1, budgetMeter)),
       dot: readDot(raw.dot, `${path}/dot`),
     };
   }
@@ -212,13 +240,15 @@ function deserializeNode(node: unknown, path: string, depth: number): Node {
   if (kind === "obj") {
     const entriesRaw = asRecord(raw.entries, `${path}/entries`);
     const tombstoneRaw = asRecord(raw.tombstone, `${path}/tombstone`);
+    budgetMeter?.count("objectEntries", Object.keys(entriesRaw).length, `${path}/entries`);
+    budgetMeter?.count("serializedElements", Object.keys(entriesRaw).length, `${path}/entries`);
 
     const entries = new Map<string, { node: Node; dot: Dot }>();
     for (const [k, v] of Object.entries(entriesRaw)) {
       const entryPath = `${path}/entries/${k}`;
       const entryRaw = asRecord(v, entryPath);
       entries.set(k, {
-        node: deserializeNode(entryRaw.node, `${entryPath}/node`, depth + 1),
+        node: deserializeNode(entryRaw.node, `${entryPath}/node`, depth + 1, budgetMeter),
         dot: readDot(entryRaw.dot, `${entryPath}/dot`),
       });
     }
@@ -236,6 +266,8 @@ function deserializeNode(node: unknown, path: string, depth: number): Node {
   }
 
   const elemsRaw = asRecord(raw.elems, `${path}/elems`);
+  budgetMeter?.count("sequenceElements", Object.keys(elemsRaw).length, `${path}/elems`);
+  budgetMeter?.count("serializedElements", Object.keys(elemsRaw).length, `${path}/elems`);
   const elems = new Map<string, RgaElem>();
   for (const [id, rawElem] of Object.entries(elemsRaw)) {
     const elemPath = `${path}/elems/${id}`;
@@ -251,7 +283,7 @@ function deserializeNode(node: unknown, path: string, depth: number): Node {
 
     const prev = readString(elem.prev, `${elemPath}/prev`);
     const tombstone = readBoolean(elem.tombstone, `${elemPath}/tombstone`);
-    const value = deserializeNode(elem.value, `${elemPath}/value`, depth + 1);
+    const value = deserializeNode(elem.value, `${elemPath}/value`, depth + 1, budgetMeter);
     const insDot = readDot(elem.insDot, `${elemPath}/insDot`);
     const delDot =
       "delDot" in elem && elem.delDot !== undefined
@@ -420,13 +452,24 @@ function readBoolean(value: unknown, path: string): boolean {
   return value;
 }
 
-function readJsonValue(value: unknown, path: string, depth: number): JsonValue {
-  assertJsonValue(value, path, depth);
+function readJsonValue(
+  value: unknown,
+  path: string,
+  depth: number,
+  budgetMeter?: ResourceBudgetMeter,
+): JsonValue {
+  assertJsonValue(value, path, depth, budgetMeter);
   return value;
 }
 
-function assertJsonValue(value: unknown, path: string, depth: number): asserts value is JsonValue {
+function assertJsonValue(
+  value: unknown,
+  path: string,
+  depth: number,
+  budgetMeter?: ResourceBudgetMeter,
+): asserts value is JsonValue {
   assertTraversalDepth(depth);
+  budgetMeter?.count("visitedNodes", 1, path);
 
   if (value === null || typeof value === "string" || typeof value === "boolean") {
     return;
@@ -441,8 +484,10 @@ function assertJsonValue(value: unknown, path: string, depth: number): asserts v
   }
 
   if (Array.isArray(value)) {
+    budgetMeter?.count("sequenceElements", value.length, path);
+    budgetMeter?.count("serializedElements", value.length, path);
     for (const [index, item] of value.entries()) {
-      assertJsonValue(item, `${path}/${index}`, depth + 1);
+      assertJsonValue(item, `${path}/${index}`, depth + 1, budgetMeter);
     }
 
     return;
@@ -452,8 +497,11 @@ function assertJsonValue(value: unknown, path: string, depth: number): asserts v
     fail("INVALID_SERIALIZED_SHAPE", path, "expected JSON value");
   }
 
-  for (const [key, child] of Object.entries(value)) {
-    assertJsonValue(child, `${path}/${key}`, depth + 1);
+  const entries = Object.entries(value);
+  budgetMeter?.count("objectEntries", entries.length, path);
+  budgetMeter?.count("serializedElements", entries.length, path);
+  for (const [key, child] of entries) {
+    assertJsonValue(child, `${path}/${key}`, depth + 1, budgetMeter);
   }
 }
 
@@ -462,6 +510,10 @@ function fail(reason: DeserializeErrorReason, path: string, message: string): ne
 }
 
 function toDeserializeFailure(error: unknown): DeserializeFailure | null {
+  if (error instanceof ResourceBudgetError) {
+    return toBudgetDeserializeFailure(error);
+  }
+
   if (error instanceof DeserializeError || error instanceof TraversalDepthError) {
     return error;
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -18,6 +18,7 @@ import type {
   Node,
   PatchErrorReason,
   PatchSemantics,
+  ResourceBudgetKind,
   TryApplyPatchAsActorResult,
   TryApplyPatchInPlaceResult,
   TryApplyPatchResult,
@@ -25,6 +26,7 @@ import type {
   VersionVector,
 } from "./types";
 
+import { ResourceBudgetError, createBudgetMeter, toBudgetApplyError } from "./budget";
 import { createClock, cloneClock } from "./clock";
 import { TraversalDepthError, toDepthApplyError } from "./depth";
 import { applyIntentsToCrdt, cloneDoc, docFromJson } from "./doc";
@@ -50,6 +52,9 @@ import { observedVersionVector } from "./version-vector";
 export class PatchError extends Error {
   readonly code: 409;
   readonly reason: PatchErrorReason;
+  readonly budget?: ResourceBudgetKind;
+  readonly limit?: number;
+  readonly actual?: number;
   readonly path?: string;
   readonly opIndex?: number;
 
@@ -70,6 +75,11 @@ export class PatchError extends Error {
 
     this.code = errorOrMessage.code;
     this.reason = errorOrMessage.reason;
+    if (errorOrMessage.reason === "RESOURCE_BUDGET_EXCEEDED") {
+      this.budget = errorOrMessage.budget;
+      this.limit = errorOrMessage.limit;
+      this.actual = errorOrMessage.actual;
+    }
     this.path = errorOrMessage.path;
     this.opIndex = errorOrMessage.opIndex;
   }
@@ -310,6 +320,8 @@ function applyPatchInternal(
     return preparedPatch;
   }
 
+  const budgetMeter = createBudgetMeter(options.resourceBudget);
+  budgetMeter?.count("patchOperations", preparedPatch.patch.length);
   const runtimePatch = preparedPatch.patch;
   const semantics: PatchSemantics = options.semantics ?? "sequential";
 
@@ -923,9 +935,15 @@ function compilePreparedIntents(
   semantics: PatchSemantics = "sequential",
   pointerCache?: Map<string, string[]>,
   opIndexOffset = 0,
+  budgetMeter?: ReturnType<typeof createBudgetMeter>,
 ): { ok: true; intents: IntentOp[] } | ApplyError {
   try {
-    const compileOptions = toCompilePatchOptions(semantics, pointerCache, opIndexOffset);
+    const compileOptions = toCompilePatchOptions(
+      semantics,
+      pointerCache,
+      opIndexOffset,
+      budgetMeter,
+    );
     if (patch.length === 1) {
       return {
         ok: true,
@@ -946,12 +964,15 @@ function toCompilePatchOptions(
   semantics: PatchSemantics,
   pointerCache?: Map<string, string[]>,
   opIndexOffset = 0,
+  budgetMeter?: ReturnType<typeof createBudgetMeter>,
 ): CompilePatchOptions {
   // Internal session hints are consumed in patch.ts but are not part of the public type.
   return {
     semantics,
+    resourceBudget: undefined,
     pointerCache,
     opIndexOffset,
+    budgetMeter,
   } as CompilePatchOptions;
 }
 
@@ -1033,6 +1054,10 @@ function mergePointerPaths(basePointer: string, nestedPointer: string): string {
 }
 
 function toApplyError(error: unknown): ApplyError {
+  if (error instanceof ResourceBudgetError) {
+    return toBudgetApplyError(error);
+  }
+
   if (error instanceof TraversalDepthError) {
     return toDepthApplyError(error);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,10 +148,7 @@ export interface LegacySerializedState {
 export type SerializedState = SerializedStateV1 | LegacySerializedState;
 
 /** Typed reasons for rejecting malformed serialized CRDT payloads. */
-export type DeserializeErrorReason =
-  | "INVALID_SERIALIZED_SHAPE"
-  | "INVALID_SERIALIZED_INVARIANT"
-  | "RESOURCE_BUDGET_EXCEEDED";
+export type DeserializeErrorReason = "INVALID_SERIALIZED_SHAPE" | "INVALID_SERIALIZED_INVARIANT";
 
 export type ResourceBudgetKind =
   | "patchOperations"
@@ -186,12 +183,10 @@ export type DeserializeFailure =
   | {
       code: 409;
       reason: DeserializeErrorReason;
-      path?: string;
+      path: string;
       message: string;
-      budget?: ResourceBudgetKind;
-      limit?: number;
-      actual?: number;
     }
+  | ResourceBudgetExceededFailure
   | {
       code: 409;
       reason: "MAX_DEPTH_EXCEEDED";

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,15 +148,49 @@ export interface LegacySerializedState {
 export type SerializedState = SerializedStateV1 | LegacySerializedState;
 
 /** Typed reasons for rejecting malformed serialized CRDT payloads. */
-export type DeserializeErrorReason = "INVALID_SERIALIZED_SHAPE" | "INVALID_SERIALIZED_INVARIANT";
+export type DeserializeErrorReason =
+  | "INVALID_SERIALIZED_SHAPE"
+  | "INVALID_SERIALIZED_INVARIANT"
+  | "RESOURCE_BUDGET_EXCEEDED";
+
+export type ResourceBudgetKind =
+  | "patchOperations"
+  | "objectEntries"
+  | "sequenceElements"
+  | "visitedNodes"
+  | "serializedElements"
+  | "arrayDiffCells";
+
+export interface ResourceBudget {
+  patchOperations?: number;
+  objectEntries?: number;
+  sequenceElements?: number;
+  visitedNodes?: number;
+  serializedElements?: number;
+  arrayDiffCells?: number;
+}
+
+export interface ResourceBudgetExceededFailure {
+  code: 409;
+  reason: "RESOURCE_BUDGET_EXCEEDED";
+  message: string;
+  budget: ResourceBudgetKind;
+  limit: number;
+  actual: number;
+  path?: string;
+  opIndex?: number;
+}
 
 /** Structured failure payload used by non-throwing deserialize helpers. */
 export type DeserializeFailure =
   | {
       code: 409;
       reason: DeserializeErrorReason;
-      path: string;
+      path?: string;
       message: string;
+      budget?: ResourceBudgetKind;
+      limit?: number;
+      actual?: number;
     }
   | {
       code: 409;
@@ -256,6 +290,7 @@ export type PatchErrorReason =
   | "INVALID_MOVE"
   | "DOT_GENERATION_EXHAUSTED"
   | "MAX_DEPTH_EXCEEDED"
+  | "RESOURCE_BUDGET_EXCEEDED"
   | "LINEAGE_MISMATCH";
 
 /** Structured conflict payload used by non-throwing APIs. */
@@ -271,6 +306,10 @@ export type ApplyError = {
   path?: string;
   /** Optional patch operation index when available. */
   opIndex?: number;
+  /** Resource-budget context when `reason` is `RESOURCE_BUDGET_EXCEEDED`. */
+  budget?: ResourceBudgetKind;
+  limit?: number;
+  actual?: number;
 };
 
 /** Result of applying a patch: success or structured conflict details. */
@@ -292,6 +331,7 @@ export type PatchSemantics = "base" | "sequential";
 /** Options for compile/validation helpers. */
 export type CompilePatchOptions = {
   semantics?: PatchSemantics;
+  resourceBudget?: ResourceBudget;
 };
 
 /**
@@ -304,6 +344,7 @@ export type ApplyPatchOptions = {
   base?: CrdtState;
   testAgainst?: "head" | "base";
   semantics?: PatchSemantics;
+  resourceBudget?: ResourceBudget;
   /**
    * Reject array inserts when the base parent path is missing.
    * Defaults to `false` to preserve legacy behavior that can auto-create
@@ -361,6 +402,7 @@ export type MergeStateOptions = {
    * Ignored when `unrelatedArrays` is also provided.
    */
   requireSharedOrigin?: boolean;
+  resourceBudget?: ResourceBudget;
 };
 
 /** Options for `mergeDoc`. */
@@ -377,7 +419,12 @@ export type MergeDocOptions = {
    * Ignored when `unrelatedArrays` is also provided.
    */
   requireSharedOrigin?: boolean;
+  resourceBudget?: ResourceBudget;
 };
+
+export interface DeserializeOptions {
+  resourceBudget?: ResourceBudget;
+}
 
 /** Non-throwing result for `mergeDoc`. */
 export type TryMergeDocResult = { ok: true; doc: Doc } | { ok: false; error: ApplyError };
@@ -427,6 +474,7 @@ export type JsonPatchToCrdtOptions = {
   bumpCounterAbove?: (ctr: number) => void;
   semantics?: PatchSemantics;
   strictParents?: boolean;
+  resourceBudget?: ResourceBudget;
 };
 
 /** Options for `crdtToJsonPatch` and `diffJsonPatch`. */
@@ -476,6 +524,7 @@ export type DiffOptions = {
    * Defaults to `"none"` for backward compatibility.
    */
   jsonValidation?: JsonValidationMode;
+  resourceBudget?: ResourceBudget;
 };
 
 /**

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -45,6 +45,7 @@ import {
   objSet,
   PatchCompileError,
   PatchError,
+  ResourceBudgetError,
   DeserializeError,
   TraversalDepthError,
   parseJsonPointer,
@@ -976,6 +977,116 @@ describe("clock and state", () => {
       expect(result.error.path).toBe("/n");
       expect(result.error.opIndex).toBe(0);
     }
+  });
+});
+
+describe("resource budgets", () => {
+  it("rejects patch programs that exceed the configured patch operation budget", () => {
+    const state = createState({ list: [0, 1] }, { actor: "A" });
+    const result = tryApplyPatch(
+      state,
+      [
+        { op: "replace", path: "/list/0", value: 10 },
+        { op: "replace", path: "/list/1", value: 11 },
+      ],
+      {
+        resourceBudget: {
+          patchOperations: 1,
+        },
+      },
+    );
+
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected patch budget rejection");
+    }
+
+    expect(result.error.reason).toBe("RESOURCE_BUDGET_EXCEEDED");
+    expect(result.error.budget).toBe("patchOperations");
+    expect(result.error.limit).toBe(1);
+    expect(result.error.actual).toBe(2);
+  });
+
+  it("rejects wide object diffs that exceed the configured object entry budget", () => {
+    const base = { keep: 1 };
+    const next = { keep: 1, addA: 2, addB: 3 };
+
+    expect(() =>
+      diffJsonPatch(base, next, {
+        resourceBudget: {
+          objectEntries: 2,
+        },
+      }),
+    ).toThrow(ResourceBudgetError);
+
+    try {
+      diffJsonPatch(base, next, {
+        resourceBudget: {
+          objectEntries: 2,
+        },
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResourceBudgetError);
+      if (error instanceof ResourceBudgetError) {
+        expect(error.reason).toBe("RESOURCE_BUDGET_EXCEEDED");
+        expect(error.budget).toBe("objectEntries");
+        expect(error.limit).toBe(2);
+        expect(error.actual).toBe(3);
+      }
+      return;
+    }
+
+    throw new Error("Expected diff budget rejection");
+  });
+
+  it("rejects merges that exceed the configured sequence element budget", () => {
+    const left = createState({ list: [1, 2] }, { actor: "A" });
+    const right = createState({ list: [3] }, { actor: "B" });
+    const result = tryMergeState(left, right, {
+      unrelatedArrays: "unsafe-union",
+      resourceBudget: {
+        sequenceElements: 2,
+      },
+    });
+
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected merge budget rejection");
+    }
+
+    expect(result.error.reason).toBe("RESOURCE_BUDGET_EXCEEDED");
+    expect(result.error.budget).toBe("sequenceElements");
+    expect(result.error.limit).toBe(2);
+    expect(result.error.actual).toBe(3);
+  });
+
+  it("rejects serialized payloads that exceed the configured element inspection budget", () => {
+    const state = createState(
+      {
+        items: [1, 2, 3],
+      },
+      { actor: "A" },
+    );
+    const serialized = serializeState(state);
+    const result = tryDeserializeState(serialized, {
+      resourceBudget: {
+        serializedElements: 2,
+      },
+    });
+
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected deserialize budget rejection");
+    }
+
+    expect(result.error.reason).toBe("RESOURCE_BUDGET_EXCEEDED");
+    if (result.error.reason !== "RESOURCE_BUDGET_EXCEEDED") {
+      throw new Error("Expected deserialize budget rejection");
+    }
+
+    expect(result.error.budget).toBe("serializedElements");
+    expect(result.error.limit).toBe(2);
+    expect(result.error.actual).toBeGreaterThan(2);
   });
 });
 

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -1039,6 +1039,20 @@ describe("resource budgets", () => {
     throw new Error("Expected diff budget rejection");
   });
 
+  it("preserves LCS fallback when array diff cells exceed the budget but LCS is skipped", () => {
+    const base = { list: [0, 1, 2, 3, 4, 5] };
+    const next = { list: [5, 4, 3, 2, 1, 0] };
+
+    expect(
+      diffJsonPatch(base, next, {
+        lcsMaxCells: 10,
+        resourceBudget: {
+          arrayDiffCells: 1,
+        },
+      }),
+    ).toEqual([{ op: "replace", path: "/list", value: next.list }]);
+  });
+
   it("rejects merges that exceed the configured sequence element budget", () => {
     const left = createState({ list: [1, 2] }, { actor: "A" });
     const right = createState({ list: [3] }, { actor: "B" });
@@ -1058,6 +1072,26 @@ describe("resource budgets", () => {
     expect(result.error.budget).toBe("sequenceElements");
     expect(result.error.limit).toBe(2);
     expect(result.error.actual).toBe(3);
+  });
+
+  it("does not double-count shared sequence elements during atomic-replace fallthrough", () => {
+    const base = createState({ list: [1, 2] }, { actor: "A" });
+    const left = applyPatch(base, [{ op: "replace", path: "/list/0", value: 10 }]);
+    const right = applyPatch(base, [{ op: "replace", path: "/list/1", value: 20 }]);
+
+    const result = tryMergeState(left, right, {
+      unrelatedArrays: "atomic-replace",
+      resourceBudget: {
+        sequenceElements: 3,
+      },
+    });
+
+    expect(result.ok).toBeTrue();
+    if (!result.ok) {
+      throw new Error(`Expected merge success, received ${result.error.message}`);
+    }
+
+    expect(toJson(result.state)).toEqual({ list: [10, 20] });
   });
 
   it("rejects serialized payloads that exceed the configured element inspection budget", () => {


### PR DESCRIPTION
## Summary
- add shared `ResourceBudget` options and a typed `ResourceBudgetError` for untrusted-input guardrails
- enforce configurable budgets across patch application, JSON diffing, CRDT merges, deserialization, and the matching low-level helpers
- export the new public types/errors and cover patch, diff, merge, and deserialize budget exhaustion with regression tests and a changeset

## Why
Issue #142 identified a denial-of-service gap for wide-but-shallow payloads and long patch programs. The library already enforced traversal depth, but callers could not cap breadth-oriented work such as patch operation count, object entry scans, sequence element scans, serialized payload inspection, or array diff work.

## Root Cause
The affected APIs traversed caller-controlled structures with only depth-based protection. That left large patch arrays, wide objects, large sequences, and broad serialized payloads free to consume CPU and memory even when nesting stayed shallow.

## Impact
Callers can now set explicit resource budgets on the public patch, diff, merge, and deserialize APIs, and receive typed `RESOURCE_BUDGET_EXCEEDED` failures when those limits are crossed. The same guardrails are also available on the corresponding low-level helpers.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`

Closes #142