### PR TITLE
[codex] Cap lcs-linear diff work by default

### DIFF
--- a/.changeset/calm-buckets-tap.md
+++ b/.changeset/calm-buckets-tap.md
@@ -1,0 +1,8 @@
+---
+"json-patch-to-crdt": minor
+---
+
+Cap `arrayStrategy: "lcs-linear"` work by default using the existing 250,000-cell unmatched-window budget.
+
+Callers that need the previous unbounded traversal can now opt out explicitly with
+`lcsLinearMaxCells: Number.POSITIVE_INFINITY`.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For array-heavy snapshots, `diffJsonPatch` and `crdtToJsonPatch` support:
 
 `lcsMaxCells` only applies to `arrayStrategy: "lcs"`. If the classic LCS matrix for the trimmed unmatched window would exceed the configured cap, the diff falls back to an atomic array `replace`.
 
-`lcsLinearMaxCells` is the matching opt-in guardrail for `arrayStrategy: "lcs-linear"`. It uses the same trimmed unmatched-window estimate, but caps worst-case runtime instead of matrix allocation. When the cap is exceeded, `lcs-linear` also falls back to an atomic array `replace`. If you do not set `lcsLinearMaxCells`, `lcs-linear` keeps its previous behavior and will continue to run without an automatic fallback.
+`lcsLinearMaxCells` is the matching guardrail for `arrayStrategy: "lcs-linear"` and defaults to `250_000`. It uses the same trimmed unmatched-window estimate, but caps worst-case runtime instead of matrix allocation. When the cap is exceeded, `lcs-linear` also falls back to an atomic array `replace`. Set `lcsLinearMaxCells: Number.POSITIVE_INFINITY` only when you explicitly want the previous unbounded behavior and accept the CPU cost for large unmatched arrays.
 
 `diffJsonPatch` keeps the existing `add`/`remove`/`replace` output by default. Set
 `emitMoves` and/or `emitCopies` to opt into deterministic RFC 6902 `move`/`copy`

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -299,7 +299,7 @@ export function compileJsonPatchOpToIntent(
  * By default arrays use a deterministic LCS strategy.
  * Pass `{ arrayStrategy: "atomic" }` for single-op array replacement.
  * Pass `{ arrayStrategy: "lcs-linear" }` for a lower-memory LCS variant.
- * Use `lcsLinearMaxCells` to optionally cap worst-case `lcs-linear` work and
+ * Use `lcsLinearMaxCells` to cap worst-case `lcs-linear` work and
  * fall back to an atomic array replacement for very large unmatched windows.
  * Pass `{ emitMoves: true }` or `{ emitCopies: true }` to opt into RFC 6902
  * move/copy emission when a deterministic rewrite is available.
@@ -1097,16 +1097,17 @@ function shouldUseLinearLcsDiff(
   options: DiffOptions,
 ): boolean {
   const cap = options.lcsLinearMaxCells;
-  if (cap === undefined || cap === Number.POSITIVE_INFINITY) {
+  if (cap === Number.POSITIVE_INFINITY) {
     return true;
   }
 
-  if (!Number.isFinite(cap) || cap < 1) {
+  const effectiveCap = cap ?? DEFAULT_LCS_MAX_CELLS;
+  if (!Number.isFinite(effectiveCap) || effectiveCap < 1) {
     return false;
   }
 
   const estimatedCells = (baseLength + 1) * (nextLength + 1);
-  return estimatedCells <= cap;
+  return estimatedCells <= effectiveCap;
 }
 
 function finalizeArrayOps(

--- a/src/types.ts
+++ b/src/types.ts
@@ -478,8 +478,8 @@ export type DiffOptions = {
    * Array diff mode.
    * - `"lcs"` (default): index-level edits using LCS.
    * - `"lcs-linear"`: index-level edits using a lower-memory LCS variant.
-   *   This reduces memory use but still has `O(n * m)` time complexity and no
-   *   automatic fallback for very large unmatched windows.
+   *   This reduces memory use but still has `O(n * m)` time complexity. Large
+   *   unmatched windows fall back to atomic replacement by default.
    * - `"atomic"`: one-op root/field replacement for changed arrays.
    */
   arrayStrategy?: "atomic" | "lcs" | "lcs-linear";
@@ -492,16 +492,16 @@ export type DiffOptions = {
    */
   lcsMaxCells?: number;
   /**
-   * Optional guardrail for `arrayStrategy: "lcs-linear"`.
+   * Guardrail for `arrayStrategy: "lcs-linear"`.
    * Uses the trimmed unmatched window size
    * (`(unmatchedBase.length + 1) * (unmatchedNext.length + 1)`) as a proxy for
    * worst-case work. When the cap is exceeded, the diff falls back to an atomic
    * array replacement instead of running the linear-space traversal.
    *
-   * Unlike `lcsMaxCells`, this is opt-in and defaults to no fallback so
-   * existing `lcs-linear` callers keep their current behavior.
+   * Defaults to `250_000`.
    *
-   * Set to `Number.POSITIVE_INFINITY` to always allow `lcs-linear`.
+   * Set to `Number.POSITIVE_INFINITY` to always allow `lcs-linear` and preserve
+   * the previous unbounded behavior.
    */
   lcsLinearMaxCells?: number;
   /**

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -567,15 +567,29 @@ describe("diffJsonPatch", () => {
     expect(ops).toEqual([{ op: "replace", path: "/arr/1250", value: -1 }]);
   });
 
+  it("uses a default guardrail for large unmatched windows with linear-space LCS", () => {
+    const baseArr = Array.from({ length: 4_000 }, (_, idx) => idx);
+    const nextArr = [...baseArr.slice(1), baseArr[0]!];
+
+    const base: JsonValue = { arr: baseArr };
+    const next: JsonValue = { arr: nextArr };
+    const ops = diffJsonPatch(base, next, { arrayStrategy: "lcs-linear" });
+
+    expect(ops).toEqual([{ op: "replace", path: "/arr", value: nextArr }]);
+  });
+
   it(
-    "avoids atomic fallback for large unmatched windows with linear-space LCS",
+    "supports opting out of the default linear-space LCS guardrail",
     () => {
       const baseArr = Array.from({ length: 4_000 }, (_, idx) => idx);
       const nextArr = [...baseArr.slice(1), baseArr[0]!];
 
       const base: JsonValue = { arr: baseArr };
       const next: JsonValue = { arr: nextArr };
-      const ops = diffJsonPatch(base, next, { arrayStrategy: "lcs-linear" });
+      const ops = diffJsonPatch(base, next, {
+        arrayStrategy: "lcs-linear",
+        lcsLinearMaxCells: Number.POSITIVE_INFINITY,
+      });
 
       expect(ops).toEqual([
         { op: "remove", path: "/arr/0" },


### PR DESCRIPTION
## Summary

Closes #143.

This changes `arrayStrategy: "lcs-linear"` so it uses the existing 250,000-cell unmatched-window budget by default. Large unmatched array windows now fall back to an atomic array `replace` instead of running the linear-space LCS traversal without a caller-provided cap.

## Why

The previous behavior left `lcs-linear` unbounded unless callers opted into `lcsLinearMaxCells`, which was a CPU availability risk for array diffing over untrusted or user-sized inputs. The root cause was that `shouldUseLinearLcsDiff` returned `true` when `lcsLinearMaxCells` was omitted.

## Changes

- Default `lcsLinearMaxCells` to the existing 250,000-cell LCS budget.
- Preserve the previous unbounded behavior behind `lcsLinearMaxCells: Number.POSITIVE_INFINITY`.
- Add regression coverage for default fallback and explicit opt-out behavior.
- Update README and `DiffOptions` docs with the migration impact.
- Add a changeset for the default behavior change.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`