### PR TITLE
fix: tighten missing array parent semantics

### DIFF
--- a/.changeset/strict-parents-rfc6902.md
+++ b/.changeset/strict-parents-rfc6902.md
@@ -1,0 +1,9 @@
+---
+"json-patch-to-crdt": minor
+---
+
+Add named strict and legacy parent-semantics profiles for RFC 6902 array inserts.
+
+`withStrictRfc6902Parents(...)` and `strictRfc6902PatchOptions` make missing array
+parents fail explicitly, while `withLegacyMissingArrayParents(...)` keeps the
+deprecated auto-create behavior available as an opt-in compatibility path.

--- a/.changeset/strict-parents-rfc6902.md
+++ b/.changeset/strict-parents-rfc6902.md
@@ -1,5 +1,5 @@
 ---
-"json-patch-to-crdt": minor
+"json-patch-to-crdt": major
 ---
 
 Add named strict and legacy parent-semantics profiles for RFC 6902 array inserts.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ applyPatch(head, [{ op: "add", path: "/items/0", value: "x" }], withStrictRfc690
 // throws PatchError: base array missing at /items
 ```
 
+The error is based on the explicit `base` snapshot used for CRDT array index
+resolution. In this example, `base` predates `/items`; without `{ base }`, the
+current `head` state would be used as the base and the insert would succeed.
+
 Callers that intentionally depend on the legacy auto-create behavior should opt
 in explicitly with `withLegacyMissingArrayParents(...)`. That compatibility
 profile is deprecated because accepting missing parents can hide invalid upstream

--- a/README.md
+++ b/README.md
@@ -158,6 +158,29 @@ try {
 
 If you prefer non-throwing results, use `tryApplyPatch(...)` / `tryMergeState(...)`.
 
+## Strict Parent Semantics
+
+RFC 6902 requires the parent of an `add` target to already exist. For compatibility
+with older CRDT intent flows, missing array parents can still be materialized for
+`/path/0` and `/path/-` inserts when `strictParents` is explicitly disabled.
+
+Use the named strict profile for RFC 6902 boundaries:
+
+```ts
+import { applyPatch, createState, withStrictRfc6902Parents } from "json-patch-to-crdt";
+
+const base = createState({}, { actor: "A" });
+const head = applyPatch(base, [{ op: "add", path: "/items", value: [] }]);
+
+applyPatch(head, [{ op: "add", path: "/items/0", value: "x" }], withStrictRfc6902Parents({ base }));
+// throws PatchError: base array missing at /items
+```
+
+Callers that intentionally depend on the legacy auto-create behavior should opt
+in explicitly with `withLegacyMissingArrayParents(...)`. That compatibility
+profile is deprecated because accepting missing parents can hide invalid upstream
+patch generation.
+
 ## Version Vector Helpers
 
 `observedVersionVector(...)` lets you inspect the highest observed counter per

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -687,7 +687,7 @@ function applyArrInsert(
   newDot: () => Dot,
   indexSession: ArrayIndexLookupSession,
   bumpCounterAbove?: (ctr: number) => void,
-  strictParents = false,
+  strictParents = true,
 ): ApplyResult | null {
   const pointer = `/${it.path.join("/")}`;
   const baseSeq = getSeqAtPath(base, it.path);
@@ -924,7 +924,8 @@ function applyArrReplace(
  * @param evalTestAgainst - Whether `test` ops are evaluated against `"head"` or `"base"`.
  * @param bumpCounterAbove - Optional hook that can fast-forward the underlying counter before inserts.
  * @param options - Optional behavior toggles.
- * @param options.strictParents - When `true`, reject array inserts whose base parent path is missing.
+ * @param options.strictParents - Reject array inserts whose base parent path is missing.
+ *   Defaults to `true`; pass `false` only for legacy missing-parent array auto-creation.
  * @returns `{ ok: true }` on success, or `{ ok: false, code: 409, message }` on conflict.
  */
 export function applyIntentsToCrdt(
@@ -959,7 +960,7 @@ export function applyIntentsToCrdt(
           newDot,
           arrayIndexSession,
           bumpCounterAbove,
-          options.strictParents ?? false,
+          options.strictParents ?? true,
         );
         break;
       case "ArrDelete":
@@ -1003,7 +1004,7 @@ export function jsonPatchToCrdt(
   newDot?: () => Dot,
   evalTestAgainst: "head" | "base" = "head",
   bumpCounterAbove?: (ctr: number) => void,
-  strictParents = false,
+  strictParents = true,
 ): ApplyResult {
   if (isJsonPatchToCrdtOptions(baseOrOptions)) {
     return jsonPatchToCrdtInternal(baseOrOptions);
@@ -1050,7 +1051,7 @@ export function jsonPatchToCrdtSafe(
   newDot?: () => Dot,
   evalTestAgainst: "head" | "base" = "head",
   bumpCounterAbove?: (ctr: number) => void,
-  strictParents = false,
+  strictParents = true,
 ): ApplyResult {
   try {
     if (isJsonPatchToCrdtOptions(baseOrOptions)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,13 @@ export { ResourceBudgetError } from "./budget";
 // JSON helpers
 export { diffJsonPatch } from "./patch";
 
+// Compatibility profiles
+export {
+  strictRfc6902PatchOptions,
+  withStrictRfc6902Parents,
+  withLegacyMissingArrayParents,
+} from "./options";
+
 // Serialization
 export {
   DeserializeError,

--- a/src/options.ts
+++ b/src/options.ts
@@ -11,9 +11,13 @@ export const strictRfc6902PatchOptions = {
  * Use this when patches come from an RFC 6902 boundary and missing array
  * parents should fail instead of being materialized.
  */
+export function withStrictRfc6902Parents(): typeof strictRfc6902PatchOptions;
 export function withStrictRfc6902Parents<T extends ApplyPatchOptions>(
-  options: T = {} as T,
-): T & typeof strictRfc6902PatchOptions {
+  options: T,
+): T & typeof strictRfc6902PatchOptions;
+export function withStrictRfc6902Parents<T extends ApplyPatchOptions>(
+  options?: T,
+): typeof strictRfc6902PatchOptions | (T & typeof strictRfc6902PatchOptions) {
   return {
     ...options,
     strictParents: true,
@@ -28,9 +32,13 @@ export function withStrictRfc6902Parents<T extends ApplyPatchOptions>(
  * flows that intentionally materialize missing arrays for `/path/0` or
  * `/path/-` inserts.
  */
+export function withLegacyMissingArrayParents(): { strictParents: false };
 export function withLegacyMissingArrayParents<T extends ApplyPatchOptions>(
-  options: T = {} as T,
-): T & { strictParents: false } {
+  options: T,
+): T & { strictParents: false };
+export function withLegacyMissingArrayParents<T extends ApplyPatchOptions>(
+  options?: T,
+): { strictParents: false } | (T & { strictParents: false }) {
   return {
     ...options,
     strictParents: false,

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,38 @@
+import type { ApplyPatchOptions } from "./types";
+
+/** Options that reject legacy missing-parent array auto-creation. */
+export const strictRfc6902PatchOptions = {
+  strictParents: true,
+} as const satisfies Pick<ApplyPatchOptions, "strictParents">;
+
+/**
+ * Build `applyPatch` options for strict RFC 6902 parent semantics.
+ *
+ * Use this when patches come from an RFC 6902 boundary and missing array
+ * parents should fail instead of being materialized.
+ */
+export function withStrictRfc6902Parents<T extends ApplyPatchOptions>(
+  options: T = {} as T,
+): T & typeof strictRfc6902PatchOptions {
+  return {
+    ...options,
+    strictParents: true,
+  };
+}
+
+/**
+ * Build `applyPatch` options for the legacy missing-parent array behavior.
+ *
+ * @deprecated Missing-parent array auto-creation is not RFC 6902 compatible.
+ * Prefer `withStrictRfc6902Parents(...)` unless you are preserving legacy data
+ * flows that intentionally materialize missing arrays for `/path/0` or
+ * `/path/-` inserts.
+ */
+export function withLegacyMissingArrayParents<T extends ApplyPatchOptions>(
+  options: T = {} as T,
+): T & { strictParents: false } {
+  return {
+    ...options,
+    strictParents: false,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,8 +342,10 @@ export type ApplyPatchOptions = {
   resourceBudget?: ResourceBudget;
   /**
    * Reject array inserts when the base parent path is missing.
-   * Defaults to `false` to preserve legacy behavior that can auto-create
-   * missing arrays for index `0` / append intents.
+   * Defaults to `true` for RFC 6902-compatible parent semantics.
+   * Use `withStrictRfc6902Parents(...)` for RFC 6902-compatible missing-parent
+   * behavior. Explicitly setting `false` preserves the legacy behavior that can
+   * auto-create missing arrays for index `0` / append intents.
    */
   strictParents?: boolean;
   /**

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -1127,7 +1127,7 @@ describe("applyIntentsToCrdt", () => {
     expect(materialize(headDoc.root)).toEqual(["remote", "seed"]);
   });
 
-  it("auto-creates arrays on insert at index 0 or append when base is missing", () => {
+  it("auto-creates arrays only when legacy missing array parents are explicit", () => {
     const baseDoc = docFromJsonWithDot({}, dot("A", 0));
     const headDoc = cloneDoc(baseDoc);
 
@@ -1136,6 +1136,9 @@ describe("applyIntentsToCrdt", () => {
       headDoc,
       [{ t: "ArrInsert", path: ["list"], index: 0, value: "a" }],
       newDotGen("A", 1),
+      "head",
+      undefined,
+      { strictParents: false },
     );
     expect(res0).toEqual({ ok: true });
     expect(materialize(headDoc.root)).toEqual({ list: ["a"] });
@@ -1153,9 +1156,30 @@ describe("applyIntentsToCrdt", () => {
         },
       ],
       newDotGen("A", 1),
+      "head",
+      undefined,
+      { strictParents: false },
     );
     expect(resAppend).toEqual({ ok: true });
     expect(materialize(headDoc2.root)).toEqual({ list: ["b"] });
+  });
+
+  it("rejects missing base arrays for intent inserts by default", () => {
+    const baseDoc = docFromJsonWithDot({}, dot("A", 0));
+    const headDoc = cloneDoc(baseDoc);
+
+    const res = applyIntentsToCrdt(
+      baseDoc,
+      headDoc,
+      [{ t: "ArrInsert", path: ["list"], index: 0, value: "a" }],
+      newDotGen("A", 1),
+    );
+
+    expect(res.ok).toBeFalse();
+    if (!res.ok) {
+      expect(res.reason).toBe("MISSING_PARENT");
+    }
+    expect(materialize(headDoc.root)).toEqual({});
   });
 
   it("rejects missing base arrays for inserts in strictParents mode", () => {

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -72,6 +72,9 @@ import {
   vvHasDot,
   vvMerge,
   JsonValueValidationError,
+  strictRfc6902PatchOptions,
+  withLegacyMissingArrayParents,
+  withStrictRfc6902Parents,
   type Dot,
   type SerializedDoc,
   type IntentOp,
@@ -597,6 +600,58 @@ describe("clock and state", () => {
     if (!result.ok) {
       expect(result.error.reason).toBe("INVALID_TARGET");
       expect(result.error.path).toBe("/a");
+    }
+  });
+
+  it("exposes a strict RFC 6902 parent profile for missing array inserts", () => {
+    const base = createState({}, { actor: "A" });
+    const head = applyPatch(base, [{ op: "add", path: "/list", value: [] }]);
+
+    const result = tryApplyPatch(
+      head,
+      [{ op: "add", path: "/list/0", value: "x" }],
+      withStrictRfc6902Parents({ base }),
+    );
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("MISSING_PARENT");
+      expect(result.error.path).toBe("/list");
+    }
+  });
+
+  it("keeps missing array parent auto-creation behind explicit legacy intent options", () => {
+    const baseDoc = docFromJsonWithDot({}, dot("A", 0));
+    const headDoc = cloneDoc(baseDoc);
+
+    const result = applyIntentsToCrdt(
+      baseDoc,
+      headDoc,
+      [{ t: "ArrInsert", path: ["list"], index: Number.POSITIVE_INFINITY, value: "legacy" }],
+      newDotGen("A", 1),
+      "head",
+      undefined,
+      withLegacyMissingArrayParents(),
+    );
+
+    expect(result.ok).toBeTrue();
+    if (result.ok) {
+      expect(materialize(headDoc.root)).toEqual({ list: ["legacy"] });
+    }
+  });
+
+  it("allows strict RFC 6902 options to be spread into applyPatch options", () => {
+    const base = createState({}, { actor: "A" });
+    const head = applyPatch(base, [{ op: "add", path: "/list", value: [] }]);
+
+    const result = tryApplyPatch(head, [{ op: "add", path: "/list/0", value: "x" }], {
+      base,
+      ...strictRfc6902PatchOptions,
+    });
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("MISSING_PARENT");
     }
   });
 


### PR DESCRIPTION
## Summary

Closes #144.

This PR tightens missing-parent array insert behavior so strict RFC 6902 semantics are explicit and the legacy auto-create behavior is only available through an explicit compatibility path.

## Changes

- Default low-level `applyIntentsToCrdt` array insert handling to reject missing base array parents.
- Add `strictRfc6902PatchOptions` and `withStrictRfc6902Parents(...)` for callers that want a named RFC 6902 profile.
- Add deprecated `withLegacyMissingArrayParents(...)` for callers that intentionally depend on missing array parent auto-creation.
- Update `ApplyPatchOptions.strictParents` docs and README migration guidance.
- Add regression tests for strict defaults, strict profile usage, and explicit legacy opt-in behavior.
- Add a changeset documenting the new compatibility profiles.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`