### PR TITLE
[codex] add safe JSON validation APIs

### DIFF
--- a/.changeset/safe-json-validation-apis.md
+++ b/.changeset/safe-json-validation-apis.md
@@ -1,0 +1,7 @@
+---
+"json-patch-to-crdt": minor
+---
+
+Add safe-by-default runtime JSON validation helpers for state creation, patch application, and JSON Patch diffs.
+
+The new `Safe` helpers use strict validation, while the new `Normalized` helpers coerce invalid runtime values into JSON-safe output. Existing APIs keep their backward-compatible `jsonValidation: "none"` default.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ vector, it returns that vector unchanged.
 
 `createState`, `applyPatch`, `diffJsonPatch`, and `crdtToJsonPatch` accept a
 `jsonValidation` option for callers that may pass runtime values through `any`.
+The default remains `"none"` for backward compatibility with earlier releases.
 
 - `"none"` keeps the current behavior with no extra runtime validation.
 - `"strict"` rejects values that are not valid JSON, including non-finite
@@ -246,13 +247,39 @@ console.log(toJson(state));
 // { keep: true, nested: {}, arr: [null] }
 ```
 
+For new untrusted-input boundaries, prefer the safe convenience helpers instead
+of relying on every call site to remember `jsonValidation`.
+
+```ts
+import {
+  applySafePatch,
+  createNormalizedState,
+  createSafeState,
+  diffSafeJsonPatch,
+} from "json-patch-to-crdt";
+
+const strictState = createSafeState(inputFromApi, { actor: "A" });
+const strictNext = applySafePatch(strictState, patchFromApi);
+const strictDelta = diffSafeJsonPatch(previousSnapshot, nextSnapshot);
+
+const normalizedState = createNormalizedState(inputFromApi, { actor: "A" });
+```
+
+The `Safe` helpers use strict validation and reject invalid runtime values. The
+`Normalized` helpers use normalization and coerce invalid runtime values into
+JSON-safe output. Existing `createState`, `applyPatch`, and `diffJsonPatch`
+calls keep their current compatibility defaults unless you opt into a validation
+mode directly.
+
 ## API Overview
 
 Main exports most apps need:
 
 - `createState(initial, { actor })`
+- `createSafeState(initial, { actor })` / `createNormalizedState(initial, { actor })`
 - `forkState(origin, actor)`
 - `applyPatch(state, patch, options?)`
+- `applySafePatch(state, patch, options?)` / `applyNormalizedPatch(state, patch, options?)`
 - `tryApplyPatch(state, patch, options?)`
 - `mergeState(local, remote, { actor })`
 - `tryMergeState(local, remote, options?)`
@@ -263,6 +290,7 @@ Main exports most apps need:
 - `compactStateTombstones(state, { stable })`
 - `toJson(stateOrDoc)`
 - `diffJsonPatch(baseJson, nextJson, options?)`
+- `diffSafeJsonPatch(baseJson, nextJson, options?)` / `diffNormalizedJsonPatch(baseJson, nextJson, options?)`
 - `serializeState(state)` / `deserializeState(payload)`
 - `validateJsonPatch(baseJson, patch, options?)`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,14 @@ export type {
   TryMergeStateResult,
   ValidatePatchResult,
 } from "./types";
-export type { SafeApplyPatchOptions, SafeCreateStateOptions, SafeDiffOptions } from "./safe";
+export type {
+  NormalizedApplyPatchOptions,
+  NormalizedCreateStateOptions,
+  NormalizedDiffOptions,
+  SafeApplyPatchOptions,
+  SafeCreateStateOptions,
+  SafeDiffOptions,
+} from "./safe";
 
 // State helpers (high-level)
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export type {
   TryMergeStateResult,
   ValidatePatchResult,
 } from "./types";
+export type { SafeApplyPatchOptions, SafeCreateStateOptions, SafeDiffOptions } from "./safe";
 
 // State helpers (high-level)
 export {
@@ -55,6 +56,16 @@ export { ResourceBudgetError } from "./budget";
 
 // JSON helpers
 export { diffJsonPatch } from "./patch";
+
+// Safe-by-default JSON validation helpers
+export {
+  applyNormalizedPatch,
+  applySafePatch,
+  createNormalizedState,
+  createSafeState,
+  diffNormalizedJsonPatch,
+  diffSafeJsonPatch,
+} from "./safe";
 
 // Compatibility profiles
 export {

--- a/src/safe.ts
+++ b/src/safe.ts
@@ -1,0 +1,66 @@
+import type {
+  ApplyPatchOptions,
+  CreateStateOptions,
+  CrdtState,
+  DiffOptions,
+  JsonPatchOp,
+  JsonValue,
+} from "./types";
+
+import { diffJsonPatch } from "./patch";
+import { applyPatch, createState } from "./state";
+
+export interface SafeCreateStateOptions extends Omit<CreateStateOptions, "jsonValidation"> {}
+
+export interface SafeApplyPatchOptions extends Omit<ApplyPatchOptions, "jsonValidation"> {}
+
+export interface SafeDiffOptions extends Omit<DiffOptions, "jsonValidation"> {}
+
+/** Create a state with strict runtime JSON validation enabled by default. */
+export function createSafeState(initial: JsonValue, options: SafeCreateStateOptions): CrdtState {
+  return createState(initial, { ...options, jsonValidation: "strict" });
+}
+
+/** Apply a patch with strict runtime JSON validation enabled by default. */
+export function applySafePatch(
+  state: CrdtState,
+  patch: JsonPatchOp[],
+  options: SafeApplyPatchOptions = {},
+): CrdtState {
+  return applyPatch(state, patch, { ...options, jsonValidation: "strict" });
+}
+
+/** Diff JSON values with strict runtime JSON validation enabled by default. */
+export function diffSafeJsonPatch(
+  base: JsonValue,
+  next: JsonValue,
+  options: SafeDiffOptions = {},
+): JsonPatchOp[] {
+  return diffJsonPatch(base, next, { ...options, jsonValidation: "strict" });
+}
+
+/** Create a state with normalizing runtime JSON validation enabled by default. */
+export function createNormalizedState(
+  initial: JsonValue,
+  options: SafeCreateStateOptions,
+): CrdtState {
+  return createState(initial, { ...options, jsonValidation: "normalize" });
+}
+
+/** Apply a patch with normalizing runtime JSON validation enabled by default. */
+export function applyNormalizedPatch(
+  state: CrdtState,
+  patch: JsonPatchOp[],
+  options: SafeApplyPatchOptions = {},
+): CrdtState {
+  return applyPatch(state, patch, { ...options, jsonValidation: "normalize" });
+}
+
+/** Diff JSON values with normalizing runtime JSON validation enabled by default. */
+export function diffNormalizedJsonPatch(
+  base: JsonValue,
+  next: JsonValue,
+  options: SafeDiffOptions = {},
+): JsonPatchOp[] {
+  return diffJsonPatch(base, next, { ...options, jsonValidation: "normalize" });
+}

--- a/src/safe.ts
+++ b/src/safe.ts
@@ -16,6 +16,12 @@ export interface SafeApplyPatchOptions extends Omit<ApplyPatchOptions, "jsonVali
 
 export interface SafeDiffOptions extends Omit<DiffOptions, "jsonValidation"> {}
 
+export interface NormalizedCreateStateOptions extends Omit<CreateStateOptions, "jsonValidation"> {}
+
+export interface NormalizedApplyPatchOptions extends Omit<ApplyPatchOptions, "jsonValidation"> {}
+
+export interface NormalizedDiffOptions extends Omit<DiffOptions, "jsonValidation"> {}
+
 /** Create a state with strict runtime JSON validation enabled by default. */
 export function createSafeState(initial: JsonValue, options: SafeCreateStateOptions): CrdtState {
   return createState(initial, { ...options, jsonValidation: "strict" });
@@ -42,7 +48,7 @@ export function diffSafeJsonPatch(
 /** Create a state with normalizing runtime JSON validation enabled by default. */
 export function createNormalizedState(
   initial: JsonValue,
-  options: SafeCreateStateOptions,
+  options: NormalizedCreateStateOptions,
 ): CrdtState {
   return createState(initial, { ...options, jsonValidation: "normalize" });
 }
@@ -51,7 +57,7 @@ export function createNormalizedState(
 export function applyNormalizedPatch(
   state: CrdtState,
   patch: JsonPatchOp[],
-  options: SafeApplyPatchOptions = {},
+  options: NormalizedApplyPatchOptions = {},
 ): CrdtState {
   return applyPatch(state, patch, { ...options, jsonValidation: "normalize" });
 }
@@ -60,7 +66,7 @@ export function applyNormalizedPatch(
 export function diffNormalizedJsonPatch(
   base: JsonValue,
   next: JsonValue,
-  options: SafeDiffOptions = {},
+  options: NormalizedDiffOptions = {},
 ): JsonPatchOp[] {
   return diffJsonPatch(base, next, { ...options, jsonValidation: "normalize" });
 }

--- a/tests/patch-diff-doc.test.ts
+++ b/tests/patch-diff-doc.test.ts
@@ -18,6 +18,8 @@ import {
   compareDot,
   compileJsonPatchToIntent,
   diffJsonPatch,
+  diffNormalizedJsonPatch,
+  diffSafeJsonPatch,
   createClock,
   nextDotForActor,
   observeDot,
@@ -294,6 +296,20 @@ describe("diffJsonPatch", () => {
       { n: null, arr: [null], keep: { x: 1 }, drop: undefined } as unknown as JsonValue,
       { jsonValidation: "normalize" },
     );
+
+    expect(ops).toEqual([]);
+  });
+
+  it("exposes strict safe diff helper", () => {
+    expect(() =>
+      diffSafeJsonPatch({ valid: true }, { n: Number.NaN } as unknown as JsonValue),
+    ).toThrow(JsonValueValidationError);
+  });
+
+  it("exposes normalizing diff helper", () => {
+    const ops = diffNormalizedJsonPatch({ nested: { keep: true } }, {
+      nested: { keep: true, when: new Date("2020-01-01") },
+    } as unknown as JsonValue);
 
     expect(ops).toEqual([]);
   });

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "bun:test";
 import type { SerializedSyncRecord, SyncEnvelope, SyncJson, SyncRecord } from "./test-utils";
 
 import {
+  applyNormalizedPatch,
+  applySafePatch,
   intersectVersionVectors,
   mergeVersionVectors,
   observedVersionVector,
@@ -25,6 +27,8 @@ import {
   ClockValidationError,
   nextDotForActor,
   observeDot,
+  createNormalizedState,
+  createSafeState,
   createState,
   forkState,
   crdtToJsonPatch,
@@ -347,6 +351,34 @@ describe("clock and state", () => {
       arr: invalidArray.map(() => null),
     });
     expect(toJson(rootState)).toBeNull();
+  });
+
+  it("exposes strict safe state and patch helpers", () => {
+    expect(() =>
+      createSafeState({ n: Number.NaN } as unknown as JsonValue, { actor: "A" }),
+    ).toThrow(JsonValueValidationError);
+
+    const state = createSafeState({ ok: true }, { actor: "A" });
+    expect(() =>
+      applySafePatch(state, [
+        { op: "add", path: "/invalid", value: new Date("2020-01-01") as unknown as JsonValue },
+      ]),
+    ).toThrow(PatchError);
+  });
+
+  it("exposes normalizing state and patch helpers", () => {
+    const state = createNormalizedState(
+      {
+        keep: true,
+        nested: { when: new Date("2020-01-01") },
+      } as unknown as JsonValue,
+      { actor: "A" },
+    );
+    const next = applyNormalizedPatch(state, [
+      { op: "add", path: "/items", value: [Number.POSITIVE_INFINITY] as unknown as JsonValue },
+    ]);
+
+    expect(toJson(next)).toEqual({ keep: true, nested: {}, items: [null] });
   });
 
   it("handles deeply nested objects in createState and toJson", () => {


### PR DESCRIPTION
## Summary

Adds safe-by-default runtime JSON validation entry points for callers that do not want the existing raw `jsonValidation: "none"` compatibility behavior:

- `createSafeState`, `applySafePatch`, and `diffSafeJsonPatch` use strict runtime JSON validation.
- `createNormalizedState`, `applyNormalizedPatch`, and `diffNormalizedJsonPatch` use normalization.
- Public option types omit `jsonValidation` so these helpers remain explicit profiles rather than another way to accidentally fall back to unsafe defaults.

## Root Cause / Context

The existing public APIs intentionally default to `jsonValidation: "none"` for backward compatibility. That preserves current behavior, but untyped callers need to remember to pass `jsonValidation: "strict"` or `jsonValidation: "normalize"` at every boundary. This PR adds obvious public API paths for strict rejection and normalization without changing the compatibility default of the existing APIs.

## Docs and Release

The README now documents the compatibility tradeoff and shows the safe helper usage. A minor changeset is included for the new public API surface.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun test`
- `bun typecheck`
- `bun run build`

Closes #145