### PR TITLE
[codex] Cache observed version vectors

### DIFF
--- a/.changeset/swift-vectors-observe.md
+++ b/.changeset/swift-vectors-observe.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Track observed version vectors incrementally for created, cloned, patched, and deserialized CRDT documents so stale-counter recovery no longer needs to rescan cached document trees.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -13,6 +13,7 @@ import type {
   ObjNode,
   RgaElem,
   RgaSeq,
+  VersionVector,
 } from "./types";
 
 import { createBudgetMeter } from "./budget";
@@ -41,6 +42,12 @@ import {
   rgaPrevForInsertAtIndex,
 } from "./rga";
 import { ROOT_KEY } from "./types";
+import {
+  observeDocVersionVectorDot,
+  observeVersionVectorDot,
+  readCachedObservedVersionVector,
+  writeCachedObservedVersionVector,
+} from "./version-vector";
 
 /**
  * Create a CRDT document from a JSON value, using fresh dots for each node.
@@ -49,7 +56,15 @@ import { ROOT_KEY } from "./types";
  * @returns A new CRDT `Doc`.
  */
 export function docFromJson(value: JsonValue, nextDot: () => Dot): Doc {
-  return { root: nodeFromJson(value, nextDot) };
+  const vv = Object.create(null) as VersionVector;
+  const root = nodeFromJson(value, () => {
+    const dot = nextDot();
+    observeVersionVectorDot(vv, dot);
+    return dot;
+  });
+  const doc = { root };
+  writeCachedObservedVersionVector(doc, vv);
+  return doc;
 }
 
 /**
@@ -398,7 +413,12 @@ function nodeFromJson(value: JsonValue, nextDot: () => Dot): Node {
 
 /** Deep-clone a CRDT document. The clone is fully independent of the original. */
 export function cloneDoc(doc: Doc): Doc {
-  return { root: cloneNode(doc.root) };
+  const cloned = { root: cloneNode(doc.root) };
+  const cached = readCachedObservedVersionVector(doc);
+  if (cached) {
+    writeCachedObservedVersionVector(cloned, cached);
+  }
+  return cloned;
 }
 
 function cloneNode(node: Node): Node {
@@ -938,42 +958,56 @@ export function applyIntentsToCrdt(
   options: { strictParents?: boolean } = {},
 ): ApplyResult {
   const arrayIndexSession = createArrayIndexLookupSession();
+  let pendingObservedDots: Dot[] = [];
+  const observedNewDot = () => {
+    const dot = newDot();
+    pendingObservedDots.push(dot);
+    return dot;
+  };
 
   for (const it of intents) {
     let fail: ApplyResult | null = null;
+    pendingObservedDots = [];
 
     switch (it.t) {
       case "Test":
         fail = applyTest(base, head, it, evalTestAgainst);
         break;
       case "ObjSet":
-        fail = applyObjSet(head, it, newDot);
+        fail = applyObjSet(head, it, observedNewDot);
         break;
       case "ObjRemove":
-        fail = applyObjRemove(head, it, newDot);
+        fail = applyObjRemove(head, it, observedNewDot);
         break;
       case "ArrInsert":
         fail = applyArrInsert(
           base,
           head,
           it,
-          newDot,
+          observedNewDot,
           arrayIndexSession,
           bumpCounterAbove,
           options.strictParents ?? true,
         );
         break;
       case "ArrDelete":
-        fail = applyArrDelete(base, head, it, newDot, arrayIndexSession);
+        fail = applyArrDelete(base, head, it, observedNewDot, arrayIndexSession);
         break;
       case "ArrReplace":
-        fail = applyArrReplace(base, head, it, newDot, arrayIndexSession);
+        fail = applyArrReplace(base, head, it, observedNewDot, arrayIndexSession);
         break;
       default:
         assertNever(it, "Unhandled intent type");
     }
 
-    if (fail) return fail;
+    if (fail) {
+      pendingObservedDots = [];
+      return fail;
+    }
+
+    for (const dot of pendingObservedDots) {
+      observeDocVersionVectorDot(head, dot);
+    }
   }
 
   return { ok: true };

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -14,6 +14,7 @@ import type {
   SerializedState,
   TryDeserializeDocResult,
   TryDeserializeStateResult,
+  VersionVector,
 } from "./types";
 
 import {
@@ -25,7 +26,11 @@ import {
 import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth } from "./depth";
 import { dotToElemId } from "./dot";
-import { observedVersionVector } from "./version-vector";
+import {
+  observeVersionVectorDot,
+  readCachedObservedVersionVector,
+  writeCachedObservedVersionVector,
+} from "./version-vector";
 
 const HEAD_ELEM_ID = "HEAD";
 const SERIALIZED_DOC_VERSION = 1 as const;
@@ -78,7 +83,10 @@ function deserializeDocInternal(data: SerializedDoc, budgetMeter?: ResourceBudge
     fail("INVALID_SERIALIZED_SHAPE", "/root", "serialized doc is missing root");
   }
 
-  return { root: deserializeNode(raw.root, "/root", 0, budgetMeter) };
+  const observed = Object.create(null) as VersionVector;
+  const doc = { root: deserializeNode(raw.root, "/root", 0, budgetMeter, observed) };
+  writeCachedObservedVersionVector(doc, observed);
+  return doc;
 }
 
 /** Non-throwing `deserializeDoc` variant with typed validation details. */
@@ -132,7 +140,7 @@ export function deserializeState(
   const actor = readActor(clockRaw.actor, "/clock/actor");
   const ctr = readCounter(clockRaw.ctr, "/clock/ctr");
   const doc = deserializeDocInternal(raw.doc as SerializedDoc, budgetMeter);
-  const observedCtr = observedVersionVector(doc)[actor] ?? 0;
+  const observedCtr = readCachedObservedVersionVector(doc)?.[actor] ?? 0;
   const clock = createClock(actor, Math.max(ctr, observedCtr));
   return { doc, clock };
 }
@@ -216,6 +224,7 @@ function deserializeNode(
   path: string,
   depth: number,
   budgetMeter?: ResourceBudgetMeter,
+  observed?: VersionVector,
 ): Node {
   assertTraversalDepth(depth);
   budgetMeter?.count("visitedNodes", 1, path);
@@ -230,10 +239,15 @@ function deserializeNode(
       fail("INVALID_SERIALIZED_SHAPE", `${path}/dot`, "lww node is missing dot");
     }
 
+    const dot = readDot(raw.dot, `${path}/dot`);
+    if (observed) {
+      observeVersionVectorDot(observed, dot);
+    }
+
     return {
       kind: "lww",
       value: structuredClone(readJsonValue(raw.value, `${path}/value`, depth + 1, budgetMeter)),
-      dot: readDot(raw.dot, `${path}/dot`),
+      dot,
     };
   }
 
@@ -247,15 +261,23 @@ function deserializeNode(
     for (const [k, v] of Object.entries(entriesRaw)) {
       const entryPath = `${path}/entries/${k}`;
       const entryRaw = asRecord(v, entryPath);
+      const dot = readDot(entryRaw.dot, `${entryPath}/dot`);
+      if (observed) {
+        observeVersionVectorDot(observed, dot);
+      }
       entries.set(k, {
-        node: deserializeNode(entryRaw.node, `${entryPath}/node`, depth + 1, budgetMeter),
-        dot: readDot(entryRaw.dot, `${entryPath}/dot`),
+        node: deserializeNode(entryRaw.node, `${entryPath}/node`, depth + 1, budgetMeter, observed),
+        dot,
       });
     }
 
     const tombstone = new Map<string, Dot>();
     for (const [k, d] of Object.entries(tombstoneRaw)) {
-      tombstone.set(k, readDot(d, `${path}/tombstone/${k}`));
+      const dot = readDot(d, `${path}/tombstone/${k}`);
+      if (observed) {
+        observeVersionVectorDot(observed, dot);
+      }
+      tombstone.set(k, dot);
     }
 
     return { kind: "obj", entries, tombstone };
@@ -283,12 +305,24 @@ function deserializeNode(
 
     const prev = readString(elem.prev, `${elemPath}/prev`);
     const tombstone = readBoolean(elem.tombstone, `${elemPath}/tombstone`);
-    const value = deserializeNode(elem.value, `${elemPath}/value`, depth + 1, budgetMeter);
+    const value = deserializeNode(
+      elem.value,
+      `${elemPath}/value`,
+      depth + 1,
+      budgetMeter,
+      observed,
+    );
     const insDot = readDot(elem.insDot, `${elemPath}/insDot`);
     const delDot =
       "delDot" in elem && elem.delDot !== undefined
         ? readDot(elem.delDot, `${elemPath}/delDot`)
         : undefined;
+    if (observed) {
+      observeVersionVectorDot(observed, insDot);
+      if (delDot) {
+        observeVersionVectorDot(observed, delDot);
+      }
+    }
     if (dotToElemId(insDot) !== id) {
       fail(
         "INVALID_SERIALIZED_INVARIANT",

--- a/src/version-vector.ts
+++ b/src/version-vector.ts
@@ -43,9 +43,12 @@ export function writeCachedObservedVersionVector(doc: Doc, vv: VersionVector): v
 }
 
 export function observeDocVersionVectorDot(doc: Doc, dot: Dot): void {
-  const cached = observedVersionVectorCache.get(doc) ?? (Object.create(null) as VersionVector);
+  const cached = observedVersionVectorCache.get(doc);
+  if (!cached) {
+    return;
+  }
+
   observeVersionVectorDot(cached, dot);
-  observedVersionVectorCache.set(doc, cached);
 }
 
 /**

--- a/src/version-vector.ts
+++ b/src/version-vector.ts
@@ -3,6 +3,7 @@ import type { CrdtState, Doc, Dot, Node, VersionVector } from "./types";
 import { assertTraversalDepth } from "./depth";
 
 let observedVersionVectorObserverForTests: ((target: Doc | CrdtState) => void) | null = null;
+const observedVersionVectorCache = new WeakMap<Doc, VersionVector>();
 
 export function readVersionVectorCounter(vv: VersionVector, actor: string): number | undefined {
   if (!Object.prototype.hasOwnProperty.call(vv, actor)) {
@@ -28,6 +29,25 @@ export function observeVersionVectorDot(vv: VersionVector, dot: Dot): void {
   }
 }
 
+export function cloneVersionVector(vv: VersionVector): VersionVector {
+  return mergeVersionVectors(vv);
+}
+
+export function readCachedObservedVersionVector(doc: Doc): VersionVector | undefined {
+  const cached = observedVersionVectorCache.get(doc);
+  return cached ? cloneVersionVector(cached) : undefined;
+}
+
+export function writeCachedObservedVersionVector(doc: Doc, vv: VersionVector): void {
+  observedVersionVectorCache.set(doc, cloneVersionVector(vv));
+}
+
+export function observeDocVersionVectorDot(doc: Doc, dot: Dot): void {
+  const cached = observedVersionVectorCache.get(doc) ?? (Object.create(null) as VersionVector);
+  observeVersionVectorDot(cached, dot);
+  observedVersionVectorCache.set(doc, cached);
+}
+
 /**
  * Inspect a document or state and return the highest observed counter per actor.
  *
@@ -36,12 +56,17 @@ export function observeVersionVectorDot(vv: VersionVector, dot: Dot): void {
  * of the currently materialized document tree.
  */
 export function observedVersionVector(target: Doc | CrdtState): VersionVector {
-  observedVersionVectorObserverForTests?.(target);
   const doc = "doc" in target ? target.doc : target;
-  const vv = Object.create(null) as VersionVector;
+  const cached = readCachedObservedVersionVector(doc);
+  const vv = cached ?? (Object.create(null) as VersionVector);
   if ("clock" in target) {
     observeVersionVectorDot(vv, { actor: target.clock.actor, ctr: target.clock.ctr });
   }
+  if (cached) {
+    return vv;
+  }
+
+  observedVersionVectorObserverForTests?.(target);
   const stack: Array<{ node: Node; depth: number }> = [{ node: doc.root, depth: 0 }];
 
   while (stack.length > 0) {
@@ -74,6 +99,7 @@ export function observedVersionVector(target: Doc | CrdtState): VersionVector {
     }
   }
 
+  writeCachedObservedVersionVector(doc, vv);
   return vv;
 }
 

--- a/tests/perf-regression.test.ts
+++ b/tests/perf-regression.test.ts
@@ -8,12 +8,15 @@ import {
   applyPatchInPlace,
   compactStateTombstones,
   createState,
+  deserializeState,
   diffJsonPatch,
   forkState,
   mergeState,
+  serializeState,
   toJson,
 } from "../src";
 import {
+  applyPatchAsActor,
   applyIntentsToCrdt,
   cloneDoc,
   compileJsonPatchToIntent,
@@ -698,6 +701,58 @@ describe("performance regressions", () => {
       team: "core",
     });
     expect(merged.clock.ctr).toBe(advancedA.clock.ctr);
+    expect(observedVersionVectorCalls).toBe(0);
+  });
+
+  it("avoids rescanning cloned documents to recover applyPatchAsActor counters", () => {
+    const base = createState({ list: ["a"], obj: { stale: true } }, { actor: "A" });
+    const deleted = applyPatch(base, [
+      { op: "remove", path: "/list/0" },
+      { op: "remove", path: "/obj/stale" },
+    ]);
+    const doc = cloneDoc(deleted.doc);
+    const staleVv = { A: 1 };
+    let observedVersionVectorCalls = 0;
+
+    setObservedVersionVectorObserverForTests(() => {
+      observedVersionVectorCalls += 1;
+    });
+
+    let next;
+    try {
+      next = applyPatchAsActor(doc, staleVv, "A", [{ op: "add", path: "/obj/fresh", value: true }]);
+    } finally {
+      setObservedVersionVectorObserverForTests(null);
+    }
+
+    expect(toJson(next.state)).toEqual({ list: [], obj: { fresh: true } });
+    expect(next.vv.A).toBeGreaterThan(deleted.clock.ctr);
+    expect(observedVersionVectorCalls).toBe(0);
+  });
+
+  it("avoids rescanning deserialized documents to repair stale clocks", () => {
+    const base = createState({ list: ["a"], obj: { stale: true } }, { actor: "A" });
+    const deleted = applyPatch(base, [
+      { op: "remove", path: "/list/0" },
+      { op: "remove", path: "/obj/stale" },
+    ]);
+    const payload = serializeState(deleted);
+    payload.clock.ctr = 0;
+    let observedVersionVectorCalls = 0;
+
+    setObservedVersionVectorObserverForTests(() => {
+      observedVersionVectorCalls += 1;
+    });
+
+    let restored;
+    try {
+      restored = deserializeState(payload);
+    } finally {
+      setObservedVersionVectorObserverForTests(null);
+    }
+
+    expect(restored.clock.ctr).toBe(deleted.clock.ctr);
+    expect(toJson(restored)).toEqual({ list: [], obj: {} });
     expect(observedVersionVectorCalls).toBe(0);
   });
 });

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -194,6 +194,21 @@ describe("dots and version vectors", () => {
     expect(observedVersionVector(removed)).toEqual({ A: removed.clock.ctr });
   });
 
+  it("does not promote partial caches for legacy unseeded docs", () => {
+    const doc = docFromJsonWithDot({ a: 1 }, dot("B", 10));
+    let ctr = 0;
+    const result = applyIntentsToCrdt(
+      doc,
+      doc,
+      [{ t: "ObjSet", path: [], key: "b", value: 2 }],
+      () => dot("A", ++ctr),
+      "base",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(observedVersionVector(doc)).toEqual({ A: 2, B: 10 });
+  });
+
   it("supports public merge, intersection, and coverage checks for version vectors", () => {
     const left = JSON.parse('{"A":3,"B":1,"__proto__":4}') as VersionVector;
     const right: VersionVector = { A: 2, B: 5, C: 1 };


### PR DESCRIPTION
Closes #147

## Summary

Track observed version-vector counters incrementally on CRDT documents so common stale-counter recovery paths can avoid rescanning the full document tree.

## What changed

- Added an internal observed-version-vector cache keyed by `Doc`.
- Seed the cache while creating documents and while deserializing node dots, including object entry dots, object tombstone dots, sequence insertion dots, and sequence delete dots.
- Preserve cached observed counters when cloning documents.
- Update cached counters from generated patch dots only after an intent succeeds, avoiding failed-operation dots being recorded as observed document state.
- Use the deserialization-time cache to repair stale serialized clocks instead of calling `observedVersionVector(doc)`.
- Added performance regression tests proving `applyPatchAsActor` and `deserializeState` recover from stale counters without full observed-vector traversal for object delete dots and sequence delete dots.
- Added a patch changeset.

## Root cause

`observedVersionVector(...)` correctly recovers the highest counter by traversing every CRDT node and retained tombstone, but helpers that already touch or create the relevant dots were discarding that information. `tryApplyPatchAsActor` and state deserialization therefore paid an O(n) full-tree scan to repair stale actor counters even when the document had just been cloned, patched, or decoded.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`