### PR TITLE
[codex] fix serialized validation budget guardrails

### DIFF
--- a/.changeset/bright-pandas-guard.md
+++ b/.changeset/bright-pandas-guard.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Count serialized object tombstones against deserialization resource budgets and document recommended serialized payload guardrails.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,31 @@ Persisted snapshot compatibility:
 The same compatibility contract applies to the lower-level `serializeDoc(...)` and
 `deserializeDoc(...)` helpers exported from `json-patch-to-crdt/internals`.
 
+### Resource Budgets for Serialized Payloads
+
+When accepting serialized CRDT payloads from network clients, pass
+`resourceBudget` limits to `deserializeState(...)`, `deserializeDoc(...)`, or the
+non-throwing `tryDeserialize*` variants. These limits reject hostile shallow
+payloads before validation allocates large maps or walks excessive element sets.
+
+```ts
+const result = tryDeserializeState(payload, {
+  resourceBudget: {
+    objectEntries: 10_000,
+    sequenceElements: 50_000,
+    serializedElements: 100_000,
+    visitedNodes: 100_000,
+  },
+});
+```
+
+Tune these caps to your product limits. For network-exposed services, start with
+caps near the largest document you intend to accept and lower them where request
+size, latency, or memory limits are tighter. `objectEntries` covers object keys
+and tombstone maps, `sequenceElements` covers RGA sequence elements and JSON
+arrays, `serializedElements` caps the combined serialized breadth, and
+`visitedNodes` caps total decoded node/value traversal.
+
 ## Error Handling
 
 `applyPatch` throws `PatchError` when a patch cannot be applied.

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -256,6 +256,8 @@ function deserializeNode(
     const tombstoneRaw = asRecord(raw.tombstone, `${path}/tombstone`);
     budgetMeter?.count("objectEntries", Object.keys(entriesRaw).length, `${path}/entries`);
     budgetMeter?.count("serializedElements", Object.keys(entriesRaw).length, `${path}/entries`);
+    budgetMeter?.count("objectEntries", Object.keys(tombstoneRaw).length, `${path}/tombstone`);
+    budgetMeter?.count("serializedElements", Object.keys(tombstoneRaw).length, `${path}/tombstone`);
 
     const entries = new Map<string, { node: Node; dot: Dot }>();
     for (const [k, v] of Object.entries(entriesRaw)) {

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -1224,6 +1224,89 @@ describe("resource budgets", () => {
     expect(result.error.limit).toBe(2);
     expect(result.error.actual).toBeGreaterThan(2);
   });
+
+  it("rejects wide serialized object payloads that exceed the configured object entry budget", () => {
+    const state = createState({ a: 1, b: 2, c: 3 }, { actor: "A" });
+    const result = tryDeserializeState(serializeState(state), {
+      resourceBudget: {
+        objectEntries: 2,
+      },
+    });
+
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected wide serialized object budget rejection");
+    }
+
+    expect(result.error.reason).toBe("RESOURCE_BUDGET_EXCEEDED");
+    if (result.error.reason !== "RESOURCE_BUDGET_EXCEEDED") {
+      throw new Error("Expected wide serialized object budget rejection");
+    }
+
+    expect(result.error.budget).toBe("objectEntries");
+    expect(result.error.limit).toBe(2);
+    expect(result.error.actual).toBe(3);
+    expect(result.error.path).toBe("/root/entries");
+  });
+
+  it("rejects large shallow serialized sequences that exceed the configured sequence budget", () => {
+    const state = createState({ items: [1, 2, 3] }, { actor: "A" });
+    const result = tryDeserializeState(serializeState(state), {
+      resourceBudget: {
+        sequenceElements: 2,
+      },
+    });
+
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected shallow serialized sequence budget rejection");
+    }
+
+    expect(result.error.reason).toBe("RESOURCE_BUDGET_EXCEEDED");
+    if (result.error.reason !== "RESOURCE_BUDGET_EXCEEDED") {
+      throw new Error("Expected shallow serialized sequence budget rejection");
+    }
+
+    expect(result.error.budget).toBe("sequenceElements");
+    expect(result.error.limit).toBe(2);
+    expect(result.error.actual).toBe(3);
+    expect(result.error.path).toBe("/root/entries/items/node/elems");
+  });
+
+  it("rejects large serialized tombstone maps that exceed object entry budgets", () => {
+    const serialized: SerializedDoc = {
+      version: 1,
+      root: {
+        kind: "obj",
+        entries: {},
+        tombstone: {
+          a: { actor: "A", ctr: 1 },
+          b: { actor: "A", ctr: 2 },
+          c: { actor: "A", ctr: 3 },
+        },
+      },
+    };
+    const result = tryDeserializeDoc(serialized, {
+      resourceBudget: {
+        objectEntries: 2,
+      },
+    });
+
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected serialized tombstone budget rejection");
+    }
+
+    expect(result.error.reason).toBe("RESOURCE_BUDGET_EXCEEDED");
+    if (result.error.reason !== "RESOURCE_BUDGET_EXCEEDED") {
+      throw new Error("Expected serialized tombstone budget rejection");
+    }
+
+    expect(result.error.budget).toBe("objectEntries");
+    expect(result.error.limit).toBe(2);
+    expect(result.error.actual).toBe(3);
+    expect(result.error.path).toBe("/root/tombstone");
+  });
 });
 
 describe("json pointer parsing", () => {


### PR DESCRIPTION
## Summary

Fixes #148 by extending serialized CRDT deserialization resource-budget enforcement to cover shallow-but-wide payloads more completely.

## What changed

- Count serialized object tombstone maps against both `objectEntries` and `serializedElements` budgets during deserialization.
- Add regression tests for wide serialized object entries, large shallow RGA sequences, and large serialized tombstone maps.
- Document recommended `resourceBudget` guardrails for network-exposed serialized payload deserialization.
- Add a patch changeset for the security hardening change.

## Root cause

Serialized object entries and sequence elements already participated in deserialization resource budgets, but object tombstone maps were validated after the entry budget checks without contributing to breadth or total serialized-element limits. A hostile payload could therefore keep nesting shallow while forcing a large tombstone-map validation pass.

## Impact

Callers using `deserializeDoc`, `deserializeState`, `tryDeserializeDoc`, or `tryDeserializeState` with `resourceBudget` now get deterministic typed `RESOURCE_BUDGET_EXCEEDED` failures when serialized tombstone maps exceed configured object-entry or serialized-element limits.

## Validation

- `bun run test:state-core`
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
- `bun lint`