### PR TITLE
feat: support AbortSignal cancellation

### DIFF
--- a/.changeset/cuddly-signals-cancel.md
+++ b/.changeset/cuddly-signals-cancel.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": minor
+---
+
+Add optional AbortSignal-compatible cancellation support to expensive diff, patch, merge, and deserialize APIs.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ For array-heavy snapshots, `diffJsonPatch` and `crdtToJsonPatch` support:
 `emitMoves` and/or `emitCopies` to opt into deterministic RFC 6902 `move`/`copy`
 rewrites.
 
+## Cancellation
+
+Expensive high-level APIs accept an optional `signal` compatible with `AbortSignal`:
+`diffJsonPatch`, `applyPatch`, `applyPatchInPlace`, `tryApplyPatch`, `tryApplyPatchInPlace`,
+`mergeState`, `tryMergeState`, `deserializeState`, and `tryDeserializeState`.
+
+Cancellation is checked at safe points between traversal steps and array-diff loop iterations.
+Immutable APIs either return no result or leave the input state unchanged when cancelled. In-place
+patch application with `atomic: true` keeps the same all-or-nothing behavior; with `atomic: false`,
+operations already applied before cancellation remain applied. Non-throwing APIs return
+`reason: "OPERATION_CANCELLED"` and throwing APIs throw their usual domain error wrappers where
+applicable.
+
 ## Serialize / Restore State
 
 ```ts

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -1,9 +1,4 @@
-import type { ApplyError, DeserializeFailure } from "./types";
-
-export interface AbortSignalLike {
-  readonly aborted: boolean;
-  readonly reason?: unknown;
-}
+import type { AbortSignalLike, ApplyError, DeserializeFailure } from "./types";
 
 export class OperationCancelledError extends Error {
   readonly reasonValue?: unknown;

--- a/src/cancellation.ts
+++ b/src/cancellation.ts
@@ -1,0 +1,53 @@
+import type { ApplyError, DeserializeFailure } from "./types";
+
+export interface AbortSignalLike {
+  readonly aborted: boolean;
+  readonly reason?: unknown;
+}
+
+export class OperationCancelledError extends Error {
+  readonly reasonValue?: unknown;
+
+  constructor(reason?: unknown) {
+    super(toCancellationMessage(reason));
+    this.name = "OperationCancelledError";
+    this.reasonValue = reason;
+  }
+}
+
+export function throwIfAborted(signal?: AbortSignalLike): void {
+  if (signal?.aborted) {
+    throw new OperationCancelledError(signal.reason);
+  }
+}
+
+export function toCancellationApplyError(error: OperationCancelledError): ApplyError {
+  return {
+    ok: false,
+    code: 409,
+    reason: "OPERATION_CANCELLED",
+    message: error.message,
+  };
+}
+
+export function toCancellationDeserializeFailure(
+  error: OperationCancelledError,
+): DeserializeFailure {
+  return {
+    code: 409,
+    reason: "OPERATION_CANCELLED",
+    message: error.message,
+  };
+}
+
+function toCancellationMessage(reason: unknown): string {
+  if (reason instanceof Error && reason.message.length > 0) {
+    return `operation cancelled: ${reason.message}`;
+  }
+
+  if (typeof reason === "string" && reason.length > 0) {
+    return `operation cancelled: ${reason}`;
+  }
+
+  return "operation cancelled";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 // Types
 export type {
   ActorId,
+  AbortSignalLike,
   ApplyError,
   ApplyPatchInPlaceOptions,
   ApplyPatchOptions,
@@ -60,6 +61,7 @@ export {
 export { JsonValueValidationError } from "./json-value";
 export { ClockValidationError } from "./clock";
 export { ResourceBudgetError } from "./budget";
+export { OperationCancelledError } from "./cancellation";
 
 // JSON helpers
 export { diffJsonPatch } from "./patch";

--- a/src/internals.ts
+++ b/src/internals.ts
@@ -59,6 +59,7 @@ export { serializeDoc, deserializeDoc, tryDeserializeDoc } from "./serialize";
 export type {
   ApplyPatchAsActorResult,
   ApplyPatchAsActorOptions,
+  AbortSignalLike,
   TryApplyPatchAsActorResult,
   ApplyResult,
   Clock,

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -19,6 +19,7 @@ import type {
 } from "./types";
 
 import { ResourceBudgetError, createBudgetMeter, toBudgetApplyError } from "./budget";
+import { OperationCancelledError, throwIfAborted, toCancellationApplyError } from "./cancellation";
 import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth, toDepthApplyError } from "./depth";
 import { compareDot } from "./dot";
@@ -48,6 +49,7 @@ type MergeConfig = {
   actor?: ActorId;
   unrelatedArrays: UnrelatedArraysStrategy;
   budgetMeter?: ReturnType<typeof createBudgetMeter>;
+  signal?: MergeDocOptions["signal"];
 };
 
 /** Error thrown by throwing merge helpers (`mergeDoc` / `mergeState`). */
@@ -101,6 +103,7 @@ export function tryMergeDoc(a: Doc, b: Doc, options: MergeDocOptions = {}): TryM
     const config: MergeConfig = {
       unrelatedArrays: resolveUnrelatedArraysStrategy(options),
       budgetMeter: createBudgetMeter(options.resourceBudget),
+      signal: options.signal,
     };
 
     if (config.unrelatedArrays === "reject") {
@@ -142,6 +145,10 @@ export function tryMergeDoc(a: Doc, b: Doc, options: MergeDocOptions = {}): TryM
       return { ok: false, error: toBudgetApplyError(error) };
     }
 
+    if (error instanceof OperationCancelledError) {
+      return { ok: false, error: toCancellationApplyError(error) };
+    }
+
     throw error;
   }
 }
@@ -178,6 +185,7 @@ export function tryMergeState(
       actor,
       unrelatedArrays: resolveUnrelatedArraysStrategy(options),
       budgetMeter: createBudgetMeter(options.resourceBudget),
+      signal: options.signal,
     };
 
     if (config.unrelatedArrays === "reject") {
@@ -221,6 +229,10 @@ export function tryMergeState(
       return { ok: false, error: toBudgetApplyError(error) };
     }
 
+    if (error instanceof OperationCancelledError) {
+      return { ok: false, error: toCancellationApplyError(error) };
+    }
+
     throw error;
   }
 }
@@ -237,6 +249,7 @@ function findSeqLineageMismatch(
   ];
 
   while (stack.length > 0) {
+    throwIfAborted(config.signal);
     const frame = stack.pop()!;
     assertTraversalDepth(frame.depth);
     pathBuffer.length = frame.depth;
@@ -341,11 +354,12 @@ function maxObservedCtrForActor(
   return best;
 }
 
-function repDot(node: Node): Dot {
+function repDot(node: Node, signal?: MergeDocOptions["signal"]): Dot {
   let best: Dot = { actor: "", ctr: 0 };
   const stack: Array<{ node: Node; depth: number }> = [{ node, depth: 0 }];
 
   while (stack.length > 0) {
+    throwIfAborted(signal);
     const frame = stack.pop()!;
     assertTraversalDepth(frame.depth);
 
@@ -395,6 +409,7 @@ function mergeNodeAtDepth(
   path: string[],
   config: MergeConfig,
 ): MergeNodeResult {
+  throwIfAborted(config.signal);
   assertTraversalDepth(depth);
   config.budgetMeter?.count("visitedNodes", 1, stringifyJsonPointer(path));
 
@@ -404,9 +419,9 @@ function mergeNodeAtDepth(
   if (a.kind === "seq" && b.kind === "seq") return mergeSeq(a, b, depth + 1, path, config);
 
   // Kind mismatch: higher representative dot wins entirely.
-  const cmp = compareDot(repDot(a), repDot(b));
-  if (cmp >= 0) return cloneNodeShallow(a, depth + 1, config.actor);
-  return cloneNodeShallow(b, depth + 1, config.actor);
+  const cmp = compareDot(repDot(a, config.signal), repDot(b, config.signal));
+  if (cmp >= 0) return cloneNodeShallow(a, depth + 1, config.actor, config.signal);
+  return cloneNodeShallow(b, depth + 1, config.actor, config.signal);
 }
 
 function mergeLww(a: LwwReg, b: LwwReg, actor?: ActorId): MergeNodeResult {
@@ -438,6 +453,7 @@ function mergeObj(
   const allTombKeys = new Set([...a.tombstone.keys(), ...b.tombstone.keys()]);
   config.budgetMeter?.count("objectEntries", allTombKeys.size, stringifyJsonPointer(path));
   for (const key of allTombKeys) {
+    throwIfAborted(config.signal);
     const da = a.tombstone.get(key);
     const db = b.tombstone.get(key);
     if (da && db) {
@@ -457,6 +473,7 @@ function mergeObj(
   const allKeys = new Set([...a.entries.keys(), ...b.entries.keys()]);
   config.budgetMeter?.count("objectEntries", allKeys.size, stringifyJsonPointer(path));
   for (const key of allKeys) {
+    throwIfAborted(config.signal);
     const ea = a.entries.get(key);
     const eb = b.entries.get(key);
 
@@ -475,11 +492,11 @@ function mergeObj(
       merged = { node: mergedNode.node, dot };
       mergedNodeMaxObservedCtr = mergedNode.maxObservedCtr;
     } else if (ea) {
-      const cloned = cloneNodeShallow(ea.node, depth + 1, config.actor);
+      const cloned = cloneNodeShallow(ea.node, depth + 1, config.actor, config.signal);
       merged = { node: cloned.node, dot: { ...ea.dot } };
       mergedNodeMaxObservedCtr = cloned.maxObservedCtr;
     } else {
-      const cloned = cloneNodeShallow(eb!.node, depth + 1, config.actor);
+      const cloned = cloneNodeShallow(eb!.node, depth + 1, config.actor, config.signal);
       merged = { node: cloned.node, dot: { ...eb!.dot } };
       mergedNodeMaxObservedCtr = cloned.maxObservedCtr;
     }
@@ -516,6 +533,7 @@ function mergeSeq(
   if (config.unrelatedArrays === "atomic-replace" && a.elems.size > 0 && b.elems.size > 0) {
     let shared = false;
     for (const id of a.elems.keys()) {
+      throwIfAborted(config.signal);
       if (b.elems.has(id)) {
         shared = true;
         break;
@@ -527,8 +545,8 @@ function mergeSeq(
         a.elems.size + b.elems.size,
         stringifyJsonPointer(path),
       );
-      const winner = compareDot(repDot(a), repDot(b)) >= 0 ? a : b;
-      return cloneNodeShallow(winner, depth, config.actor);
+      const winner = compareDot(repDot(a, config.signal), repDot(b, config.signal)) >= 0 ? a : b;
+      return cloneNodeShallow(winner, depth, config.actor, config.signal);
     }
   }
 
@@ -539,6 +557,7 @@ function mergeSeq(
   const allIds = new Set([...a.elems.keys(), ...b.elems.keys()]);
   config.budgetMeter?.count("sequenceElements", allIds.size, stringifyJsonPointer(path));
   for (const id of allIds) {
+    throwIfAborted(config.signal);
     const ea = a.elems.get(id);
     const eb = b.elems.get(id);
 
@@ -579,11 +598,11 @@ function mergeSeq(
         maxObservedCtrForDot(mergedDeleteDot, config.actor),
       );
     } else if (ea) {
-      const cloned = cloneElem(ea, depth + 1, config.actor);
+      const cloned = cloneElem(ea, depth + 1, config.actor, config.signal);
       elems.set(id, cloned.elem);
       maxObservedCtr = Math.max(maxObservedCtr, cloned.maxObservedCtr);
     } else {
-      const cloned = cloneElem(eb!, depth + 1, config.actor);
+      const cloned = cloneElem(eb!, depth + 1, config.actor, config.signal);
       elems.set(id, cloned.elem);
       maxObservedCtr = Math.max(maxObservedCtr, cloned.maxObservedCtr);
     }
@@ -600,9 +619,11 @@ function cloneElem(
   e: RgaElem,
   depth: number,
   actor?: ActorId,
+  signal?: MergeDocOptions["signal"],
 ): { elem: RgaElem; maxObservedCtr: number } {
+  throwIfAborted(signal);
   assertTraversalDepth(depth);
-  const value = cloneNodeShallow(e.value, depth + 1, actor);
+  const value = cloneNodeShallow(e.value, depth + 1, actor, signal);
   return {
     elem: {
       id: e.id,
@@ -636,7 +657,13 @@ function mergeDeleteDot(a?: Dot, b?: Dot): Dot | undefined {
   return undefined;
 }
 
-function cloneNodeShallow(node: Node, depth: number, actor?: ActorId): MergeNodeResult {
+function cloneNodeShallow(
+  node: Node,
+  depth: number,
+  actor?: ActorId,
+  signal?: MergeDocOptions["signal"],
+): MergeNodeResult {
+  throwIfAborted(signal);
   assertTraversalDepth(depth);
   switch (node.kind) {
     case "lww":
@@ -648,7 +675,8 @@ function cloneNodeShallow(node: Node, depth: number, actor?: ActorId): MergeNode
       const entries = new Map<string, { node: Node; dot: Dot }>();
       let maxObservedCtr = 0;
       for (const [k, v] of node.entries) {
-        const cloned = cloneNodeShallow(v.node, depth + 1, actor);
+        throwIfAborted(signal);
+        const cloned = cloneNodeShallow(v.node, depth + 1, actor, signal);
         entries.set(k, { node: cloned.node, dot: { ...v.dot } });
         maxObservedCtr = Math.max(
           maxObservedCtr,
@@ -658,6 +686,7 @@ function cloneNodeShallow(node: Node, depth: number, actor?: ActorId): MergeNode
       }
       const tombstone = new Map<string, Dot>();
       for (const [k, d] of node.tombstone) {
+        throwIfAborted(signal);
         tombstone.set(k, { ...d });
         maxObservedCtr = Math.max(maxObservedCtr, maxObservedCtrForDot(d, actor));
       }
@@ -667,7 +696,8 @@ function cloneNodeShallow(node: Node, depth: number, actor?: ActorId): MergeNode
       const elems = new Map<string, RgaElem>();
       let maxObservedCtr = 0;
       for (const [id, e] of node.elems) {
-        const cloned = cloneElem(e, depth + 1, actor);
+        throwIfAborted(signal);
+        const cloned = cloneElem(e, depth + 1, actor, signal);
         elems.set(id, cloned.elem);
         maxObservedCtr = Math.max(maxObservedCtr, cloned.maxObservedCtr);
       }

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types";
 
 import { ResourceBudgetMeter, createBudgetMeter } from "./budget";
+import { throwIfAborted } from "./cancellation";
 import { assertTraversalDepth } from "./depth";
 import { coerceRuntimeJsonValue } from "./json-value";
 import { ROOT_KEY } from "./types";
@@ -319,6 +320,7 @@ export function diffJsonPatch(
   const runtimeNext = coerceRuntimeJsonValue(next, runtimeMode);
   const ops: JsonPatchOp[] = [];
   const path: string[] = [];
+  throwIfAborted(options.signal);
   diffValue(path, runtimeBase, runtimeNext, ops, options, budgetMeter);
   return ops;
 }
@@ -334,6 +336,7 @@ function diffValue(
   const stack: DiffFrame[] = [{ kind: "value", base, next }];
 
   while (stack.length > 0) {
+    throwIfAborted(options.signal);
     const frame = stack.pop()!;
 
     if (frame.kind === "path-pop") {
@@ -655,7 +658,7 @@ function diffArrayWithLcsMatrix(
   options: DiffOptions,
   budgetMeter?: ResourceBudgetMeter,
 ): boolean {
-  const window = trimEqualArrayEdges(base, next);
+  const window = trimEqualArrayEdges(base, next, options);
   const baseStart = window.baseStart;
   const nextStart = window.nextStart;
   const n = window.unmatchedBaseLength;
@@ -681,6 +684,7 @@ function diffArrayWithLcsMatrix(
     nextStart,
     nextStart + m,
     steps,
+    options,
   );
   pushArrayPatchOps(path, window.prefixLength, steps, ops, base, options);
   return true;
@@ -694,7 +698,7 @@ function diffArrayWithLinearLcs(
   options: DiffOptions,
   budgetMeter?: ResourceBudgetMeter,
 ): boolean {
-  const window = trimEqualArrayEdges(base, next);
+  const window = trimEqualArrayEdges(base, next, options);
   budgetMeter?.count(
     "sequenceElements",
     window.unmatchedBaseLength + window.unmatchedNextLength,
@@ -718,13 +722,18 @@ function diffArrayWithLinearLcs(
     window.nextStart,
     window.nextStart + window.unmatchedNextLength,
     steps,
+    options,
   );
 
   pushArrayPatchOps(path, window.prefixLength, steps, ops, base, options);
   return true;
 }
 
-function trimEqualArrayEdges(base: JsonValue[], next: JsonValue[]): TrimmedArrayWindow {
+function trimEqualArrayEdges(
+  base: JsonValue[],
+  next: JsonValue[],
+  options: DiffOptions,
+): TrimmedArrayWindow {
   const baseLength = base.length;
   const nextLength = next.length;
   let prefixLength = 0;
@@ -734,6 +743,7 @@ function trimEqualArrayEdges(base: JsonValue[], next: JsonValue[]): TrimmedArray
     prefixLength < nextLength &&
     jsonEquals(base[prefixLength]!, next[prefixLength]!)
   ) {
+    throwIfAborted(options.signal);
     prefixLength += 1;
   }
 
@@ -743,6 +753,7 @@ function trimEqualArrayEdges(base: JsonValue[], next: JsonValue[]): TrimmedArray
     suffixLength < nextLength - prefixLength &&
     jsonEquals(base[baseLength - 1 - suffixLength]!, next[nextLength - 1 - suffixLength]!)
   ) {
+    throwIfAborted(options.signal);
     suffixLength += 1;
   }
 
@@ -763,7 +774,9 @@ function buildArrayEditScriptLinearSpace(
   nextStart: number,
   nextEnd: number,
   steps: ArrayDiffStep[],
+  options: DiffOptions,
 ): void {
+  throwIfAborted(options.signal);
   const unmatchedBaseLength = baseEnd - baseStart;
   const unmatchedNextLength = nextEnd - nextStart;
 
@@ -782,23 +795,48 @@ function buildArrayEditScriptLinearSpace(
   }
 
   if (unmatchedBaseLength === 1) {
-    pushSingleBaseElementSteps(base, baseStart, next, nextStart, nextEnd, steps);
+    pushSingleBaseElementSteps(base, baseStart, next, nextStart, nextEnd, steps, options);
     return;
   }
 
   if (unmatchedNextLength === 1) {
-    pushSingleNextElementSteps(base, baseStart, baseEnd, next, nextStart, steps);
+    pushSingleNextElementSteps(base, baseStart, baseEnd, next, nextStart, steps, options);
     return;
   }
 
   if (shouldUseMatrixBaseCase(unmatchedBaseLength, unmatchedNextLength)) {
-    buildArrayEditScriptWithMatrix(base, baseStart, baseEnd, next, nextStart, nextEnd, steps);
+    buildArrayEditScriptWithMatrix(
+      base,
+      baseStart,
+      baseEnd,
+      next,
+      nextStart,
+      nextEnd,
+      steps,
+      options,
+    );
     return;
   }
 
   const baseMid = baseStart + Math.floor(unmatchedBaseLength / 2);
-  const forwardScores = computeLcsPrefixLengths(base, baseStart, baseMid, next, nextStart, nextEnd);
-  const reverseScores = computeLcsSuffixLengths(base, baseMid, baseEnd, next, nextStart, nextEnd);
+  const forwardScores = computeLcsPrefixLengths(
+    base,
+    baseStart,
+    baseMid,
+    next,
+    nextStart,
+    nextEnd,
+    options,
+  );
+  const reverseScores = computeLcsSuffixLengths(
+    base,
+    baseMid,
+    baseEnd,
+    next,
+    nextStart,
+    nextEnd,
+    options,
+  );
 
   let bestOffset = 0;
   let bestScore = Number.NEGATIVE_INFINITY;
@@ -813,8 +851,17 @@ function buildArrayEditScriptLinearSpace(
   }
 
   const nextMid = nextStart + bestOffset;
-  buildArrayEditScriptLinearSpace(base, baseStart, baseMid, next, nextStart, nextMid, steps);
-  buildArrayEditScriptLinearSpace(base, baseMid, baseEnd, next, nextMid, nextEnd, steps);
+  buildArrayEditScriptLinearSpace(
+    base,
+    baseStart,
+    baseMid,
+    next,
+    nextStart,
+    nextMid,
+    steps,
+    options,
+  );
+  buildArrayEditScriptLinearSpace(base, baseMid, baseEnd, next, nextMid, nextEnd, steps, options);
 }
 
 function pushSingleBaseElementSteps(
@@ -824,8 +871,15 @@ function pushSingleBaseElementSteps(
   nextStart: number,
   nextEnd: number,
   steps: ArrayDiffStep[],
+  options: DiffOptions,
 ): void {
-  const matchIndex = findFirstMatchingIndexInNext(base[baseStart]!, next, nextStart, nextEnd);
+  const matchIndex = findFirstMatchingIndexInNext(
+    base[baseStart]!,
+    next,
+    nextStart,
+    nextEnd,
+    options,
+  );
 
   if (matchIndex === -1) {
     steps.push({ kind: "remove" });
@@ -854,8 +908,15 @@ function pushSingleNextElementSteps(
   next: JsonValue[],
   nextStart: number,
   steps: ArrayDiffStep[],
+  options: DiffOptions,
 ): void {
-  const matchIndex = findFirstMatchingIndexInBase(next[nextStart]!, base, baseStart, baseEnd);
+  const matchIndex = findFirstMatchingIndexInBase(
+    next[nextStart]!,
+    base,
+    baseStart,
+    baseEnd,
+    options,
+  );
 
   if (matchIndex === -1) {
     for (let baseIndex = baseStart; baseIndex < baseEnd; baseIndex++) {
@@ -882,8 +943,10 @@ function findFirstMatchingIndexInNext(
   next: JsonValue[],
   nextStart: number,
   nextEnd: number,
+  options: DiffOptions,
 ): number {
   for (let nextIndex = nextStart; nextIndex < nextEnd; nextIndex++) {
+    throwIfAborted(options.signal);
     if (jsonEquals(target, next[nextIndex]!)) {
       return nextIndex;
     }
@@ -897,8 +960,10 @@ function findFirstMatchingIndexInBase(
   base: JsonValue[],
   baseStart: number,
   baseEnd: number,
+  options: DiffOptions,
 ): number {
   for (let baseIndex = baseStart; baseIndex < baseEnd; baseIndex++) {
+    throwIfAborted(options.signal);
     if (jsonEquals(target, base[baseIndex]!)) {
       return baseIndex;
     }
@@ -919,6 +984,7 @@ function buildArrayEditScriptWithMatrix(
   nextStart: number,
   nextEnd: number,
   steps: ArrayDiffStep[],
+  options: DiffOptions,
 ): void {
   const unmatchedBaseLength = baseEnd - baseStart;
   const unmatchedNextLength = nextEnd - nextStart;
@@ -927,6 +993,7 @@ function buildArrayEditScriptWithMatrix(
   );
 
   for (let baseOffset = unmatchedBaseLength - 1; baseOffset >= 0; baseOffset--) {
+    throwIfAborted(options.signal);
     for (let nextOffset = unmatchedNextLength - 1; nextOffset >= 0; nextOffset--) {
       if (jsonEquals(base[baseStart + baseOffset]!, next[nextStart + nextOffset]!)) {
         lcs[baseOffset]![nextOffset] = 1 + lcs[baseOffset + 1]![nextOffset + 1]!;
@@ -943,6 +1010,7 @@ function buildArrayEditScriptWithMatrix(
   let nextOffset = 0;
 
   while (baseOffset < unmatchedBaseLength || nextOffset < unmatchedNextLength) {
+    throwIfAborted(options.signal);
     if (
       baseOffset < unmatchedBaseLength &&
       nextOffset < unmatchedNextLength &&
@@ -980,12 +1048,14 @@ function computeLcsPrefixLengths(
   next: JsonValue[],
   nextStart: number,
   nextEnd: number,
+  options: DiffOptions,
 ): Int32Array {
   const unmatchedNextLength = nextEnd - nextStart;
   let previousRow = new Int32Array(unmatchedNextLength + 1);
   let currentRow = new Int32Array(unmatchedNextLength + 1);
 
   for (let baseIndex = baseStart; baseIndex < baseEnd; baseIndex++) {
+    throwIfAborted(options.signal);
     for (let nextOffset = 0; nextOffset < unmatchedNextLength; nextOffset++) {
       if (jsonEquals(base[baseIndex]!, next[nextStart + nextOffset]!)) {
         currentRow[nextOffset + 1] = previousRow[nextOffset]! + 1;
@@ -1013,12 +1083,14 @@ function computeLcsSuffixLengths(
   next: JsonValue[],
   nextStart: number,
   nextEnd: number,
+  options: DiffOptions,
 ): Int32Array {
   const unmatchedNextLength = nextEnd - nextStart;
   let previousRow = new Int32Array(unmatchedNextLength + 1);
   let currentRow = new Int32Array(unmatchedNextLength + 1);
 
   for (let baseIndex = baseEnd - 1; baseIndex >= baseStart; baseIndex--) {
+    throwIfAborted(options.signal);
     for (let nextOffset = unmatchedNextLength - 1; nextOffset >= 0; nextOffset--) {
       if (jsonEquals(base[baseIndex]!, next[nextStart + nextOffset]!)) {
         currentRow[nextOffset] = previousRow[nextOffset + 1]! + 1;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -135,25 +135,33 @@ export function deserializeState(
   data: SerializedState,
   options: DeserializeOptions = {},
 ): CrdtState {
-  const raw = readSerializedStateEnvelope(data);
-  const budgetMeter = createBudgetMeter(options.resourceBudget);
-  throwIfAborted(options.signal);
+  try {
+    const raw = readSerializedStateEnvelope(data);
+    const budgetMeter = createBudgetMeter(options.resourceBudget);
+    throwIfAborted(options.signal);
 
-  if (!("doc" in raw)) {
-    fail("INVALID_SERIALIZED_SHAPE", "/doc", "serialized state is missing doc");
+    if (!("doc" in raw)) {
+      fail("INVALID_SERIALIZED_SHAPE", "/doc", "serialized state is missing doc");
+    }
+
+    if (!("clock" in raw)) {
+      fail("INVALID_SERIALIZED_SHAPE", "/clock", "serialized state is missing clock");
+    }
+
+    const clockRaw = asRecord(raw.clock, "/clock");
+    const actor = readActor(clockRaw.actor, "/clock/actor");
+    const ctr = readCounter(clockRaw.ctr, "/clock/ctr");
+    const doc = deserializeDocInternal(raw.doc as SerializedDoc, budgetMeter, options.signal);
+    const observedCtr = readCachedObservedVersionVector(doc)?.[actor] ?? 0;
+    const clock = createClock(actor, Math.max(ctr, observedCtr));
+    return { doc, clock };
+  } catch (error) {
+    if (error instanceof OperationCancelledError) {
+      throw new DeserializeError("OPERATION_CANCELLED", "/", error.message);
+    }
+
+    throw error;
   }
-
-  if (!("clock" in raw)) {
-    fail("INVALID_SERIALIZED_SHAPE", "/clock", "serialized state is missing clock");
-  }
-
-  const clockRaw = asRecord(raw.clock, "/clock");
-  const actor = readActor(clockRaw.actor, "/clock/actor");
-  const ctr = readCounter(clockRaw.ctr, "/clock/ctr");
-  const doc = deserializeDocInternal(raw.doc as SerializedDoc, budgetMeter, options.signal);
-  const observedCtr = readCachedObservedVersionVector(doc)?.[actor] ?? 0;
-  const clock = createClock(actor, Math.max(ctr, observedCtr));
-  return { doc, clock };
 }
 
 /** Non-throwing `deserializeState` variant with typed validation details. */

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -23,6 +23,11 @@ import {
   createBudgetMeter,
   toBudgetDeserializeFailure,
 } from "./budget";
+import {
+  OperationCancelledError,
+  throwIfAborted,
+  toCancellationDeserializeFailure,
+} from "./cancellation";
 import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth } from "./depth";
 import { dotToElemId } from "./dot";
@@ -73,10 +78,15 @@ export function serializeDoc(doc: Doc): SerializedDoc {
 /** Reconstruct a CRDT document from its serialized form. */
 export function deserializeDoc(data: SerializedDoc, options: DeserializeOptions = {}): Doc {
   const budgetMeter = createBudgetMeter(options.resourceBudget);
-  return deserializeDocInternal(data, budgetMeter);
+  return deserializeDocInternal(data, budgetMeter, options.signal);
 }
 
-function deserializeDocInternal(data: SerializedDoc, budgetMeter?: ResourceBudgetMeter): Doc {
+function deserializeDocInternal(
+  data: SerializedDoc,
+  budgetMeter?: ResourceBudgetMeter,
+  signal?: DeserializeOptions["signal"],
+): Doc {
+  throwIfAborted(signal);
   const raw = readSerializedDocEnvelope(data);
 
   if (!("root" in raw)) {
@@ -84,7 +94,7 @@ function deserializeDocInternal(data: SerializedDoc, budgetMeter?: ResourceBudge
   }
 
   const observed = Object.create(null) as VersionVector;
-  const doc = { root: deserializeNode(raw.root, "/root", 0, budgetMeter, observed) };
+  const doc = { root: deserializeNode(raw.root, "/root", 0, budgetMeter, observed, signal) };
   writeCachedObservedVersionVector(doc, observed);
   return doc;
 }
@@ -127,6 +137,7 @@ export function deserializeState(
 ): CrdtState {
   const raw = readSerializedStateEnvelope(data);
   const budgetMeter = createBudgetMeter(options.resourceBudget);
+  throwIfAborted(options.signal);
 
   if (!("doc" in raw)) {
     fail("INVALID_SERIALIZED_SHAPE", "/doc", "serialized state is missing doc");
@@ -139,7 +150,7 @@ export function deserializeState(
   const clockRaw = asRecord(raw.clock, "/clock");
   const actor = readActor(clockRaw.actor, "/clock/actor");
   const ctr = readCounter(clockRaw.ctr, "/clock/ctr");
-  const doc = deserializeDocInternal(raw.doc as SerializedDoc, budgetMeter);
+  const doc = deserializeDocInternal(raw.doc as SerializedDoc, budgetMeter, options.signal);
   const observedCtr = readCachedObservedVersionVector(doc)?.[actor] ?? 0;
   const clock = createClock(actor, Math.max(ctr, observedCtr));
   return { doc, clock };
@@ -225,7 +236,9 @@ function deserializeNode(
   depth: number,
   budgetMeter?: ResourceBudgetMeter,
   observed?: VersionVector,
+  signal?: DeserializeOptions["signal"],
 ): Node {
+  throwIfAborted(signal);
   assertTraversalDepth(depth);
   budgetMeter?.count("visitedNodes", 1, path);
   const raw = asRecord(node, path);
@@ -246,7 +259,9 @@ function deserializeNode(
 
     return {
       kind: "lww",
-      value: structuredClone(readJsonValue(raw.value, `${path}/value`, depth + 1, budgetMeter)),
+      value: structuredClone(
+        readJsonValue(raw.value, `${path}/value`, depth + 1, budgetMeter, signal),
+      ),
       dot,
     };
   }
@@ -261,6 +276,7 @@ function deserializeNode(
 
     const entries = new Map<string, { node: Node; dot: Dot }>();
     for (const [k, v] of Object.entries(entriesRaw)) {
+      throwIfAborted(signal);
       const entryPath = `${path}/entries/${k}`;
       const entryRaw = asRecord(v, entryPath);
       const dot = readDot(entryRaw.dot, `${entryPath}/dot`);
@@ -268,13 +284,21 @@ function deserializeNode(
         observeVersionVectorDot(observed, dot);
       }
       entries.set(k, {
-        node: deserializeNode(entryRaw.node, `${entryPath}/node`, depth + 1, budgetMeter, observed),
+        node: deserializeNode(
+          entryRaw.node,
+          `${entryPath}/node`,
+          depth + 1,
+          budgetMeter,
+          observed,
+          signal,
+        ),
         dot,
       });
     }
 
     const tombstone = new Map<string, Dot>();
     for (const [k, d] of Object.entries(tombstoneRaw)) {
+      throwIfAborted(signal);
       const dot = readDot(d, `${path}/tombstone/${k}`);
       if (observed) {
         observeVersionVectorDot(observed, dot);
@@ -294,6 +318,7 @@ function deserializeNode(
   budgetMeter?.count("serializedElements", Object.keys(elemsRaw).length, `${path}/elems`);
   const elems = new Map<string, RgaElem>();
   for (const [id, rawElem] of Object.entries(elemsRaw)) {
+    throwIfAborted(signal);
     const elemPath = `${path}/elems/${id}`;
     const elem = asRecord(rawElem, elemPath);
     const elemId = readString(elem.id, `${elemPath}/id`);
@@ -313,6 +338,7 @@ function deserializeNode(
       depth + 1,
       budgetMeter,
       observed,
+      signal,
     );
     const insDot = readDot(elem.insDot, `${elemPath}/insDot`);
     const delDot =
@@ -351,6 +377,7 @@ function deserializeNode(
   }
 
   for (const elem of elems.values()) {
+    throwIfAborted(signal);
     if (elem.prev === elem.id) {
       fail(
         "INVALID_SERIALIZED_INVARIANT",
@@ -493,8 +520,9 @@ function readJsonValue(
   path: string,
   depth: number,
   budgetMeter?: ResourceBudgetMeter,
+  signal?: DeserializeOptions["signal"],
 ): JsonValue {
-  assertJsonValue(value, path, depth, budgetMeter);
+  assertJsonValue(value, path, depth, budgetMeter, signal);
   return value;
 }
 
@@ -503,7 +531,9 @@ function assertJsonValue(
   path: string,
   depth: number,
   budgetMeter?: ResourceBudgetMeter,
+  signal?: DeserializeOptions["signal"],
 ): asserts value is JsonValue {
+  throwIfAborted(signal);
   assertTraversalDepth(depth);
   budgetMeter?.count("visitedNodes", 1, path);
 
@@ -523,7 +553,8 @@ function assertJsonValue(
     budgetMeter?.count("sequenceElements", value.length, path);
     budgetMeter?.count("serializedElements", value.length, path);
     for (const [index, item] of value.entries()) {
-      assertJsonValue(item, `${path}/${index}`, depth + 1, budgetMeter);
+      throwIfAborted(signal);
+      assertJsonValue(item, `${path}/${index}`, depth + 1, budgetMeter, signal);
     }
 
     return;
@@ -537,7 +568,8 @@ function assertJsonValue(
   budgetMeter?.count("objectEntries", entries.length, path);
   budgetMeter?.count("serializedElements", entries.length, path);
   for (const [key, child] of entries) {
-    assertJsonValue(child, `${path}/${key}`, depth + 1, budgetMeter);
+    throwIfAborted(signal);
+    assertJsonValue(child, `${path}/${key}`, depth + 1, budgetMeter, signal);
   }
 }
 
@@ -548,6 +580,10 @@ function fail(reason: DeserializeErrorReason, path: string, message: string): ne
 function toDeserializeFailure(error: unknown): DeserializeFailure | null {
   if (error instanceof ResourceBudgetError) {
     return toBudgetDeserializeFailure(error);
+  }
+
+  if (error instanceof OperationCancelledError) {
+    return toCancellationDeserializeFailure(error);
   }
 
   if (error instanceof DeserializeError || error instanceof TraversalDepthError) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -27,6 +27,7 @@ import type {
 } from "./types";
 
 import { ResourceBudgetError, createBudgetMeter, toBudgetApplyError } from "./budget";
+import { OperationCancelledError, throwIfAborted, toCancellationApplyError } from "./cancellation";
 import { createClock, cloneClock } from "./clock";
 import { TraversalDepthError, toDepthApplyError } from "./depth";
 import { applyIntentsToCrdt, cloneDoc, docFromJson } from "./doc";
@@ -176,21 +177,21 @@ export function tryApplyPatch(
   patch: JsonPatchOp[],
   options: ApplyPatchOptions = {},
 ): TryApplyPatchResult {
-  const nextState: CrdtState = {
-    doc: cloneDoc(state.doc),
-    clock: cloneClock(state.clock),
-  };
-
   try {
+    throwIfAborted(options.signal);
+    const nextState: CrdtState = {
+      doc: cloneDoc(state.doc),
+      clock: cloneClock(state.clock),
+    };
     const result = applyPatchInternal(nextState, patch, options, "batch");
     if (!result.ok) {
       return { ok: false, error: result };
     }
+
+    return { ok: true, state: nextState };
   } catch (error) {
     return { ok: false, error: toApplyError(error) };
   }
-
-  return { ok: true, state: nextState };
 }
 
 /** Non-throwing in-place patch application variant. */
@@ -299,6 +300,7 @@ function toApplyPatchOptionsForActor(options: ApplyPatchAsActorOptions): ApplyPa
     testAgainst: options.testAgainst,
     strictParents: options.strictParents,
     jsonValidation: options.jsonValidation,
+    signal: options.signal,
     base: options.base
       ? {
           doc: options.base,
@@ -314,6 +316,7 @@ function applyPatchInternal(
   options: ApplyPatchOptions,
   _execution: "batch" | "step",
 ): ApplyResult {
+  throwIfAborted(options.signal);
   const jsonValidation = options.jsonValidation ?? "none";
   const preparedPatch = preparePatchPayloadsSafe(patch, jsonValidation);
   if (!preparedPatch.ok) {
@@ -339,6 +342,7 @@ function applyPatchInternal(
     };
 
     for (const [opIndex, op] of runtimePatch.entries()) {
+      throwIfAborted(options.signal);
       const baseDoc = explicitBaseState ? explicitBaseState.doc : state.doc;
       const step = applyPatchOpSequential(
         state,
@@ -1054,6 +1058,10 @@ function mergePointerPaths(basePointer: string, nestedPointer: string): string {
 }
 
 function toApplyError(error: unknown): ApplyError {
+  if (error instanceof OperationCancelledError) {
+    return toCancellationApplyError(error);
+  }
+
   if (error instanceof ResourceBudgetError) {
     return toBudgetApplyError(error);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,7 +148,10 @@ export interface LegacySerializedState {
 export type SerializedState = SerializedStateV1 | LegacySerializedState;
 
 /** Typed reasons for rejecting malformed serialized CRDT payloads. */
-export type DeserializeErrorReason = "INVALID_SERIALIZED_SHAPE" | "INVALID_SERIALIZED_INVARIANT";
+export type DeserializeErrorReason =
+  | "INVALID_SERIALIZED_SHAPE"
+  | "INVALID_SERIALIZED_INVARIANT"
+  | "OPERATION_CANCELLED";
 
 export type ResourceBudgetKind =
   | "patchOperations"
@@ -187,6 +190,11 @@ export type DeserializeFailure =
       message: string;
     }
   | ResourceBudgetExceededFailure
+  | {
+      code: 409;
+      reason: "OPERATION_CANCELLED";
+      message: string;
+    }
   | {
       code: 409;
       reason: "MAX_DEPTH_EXCEEDED";
@@ -266,6 +274,7 @@ export type ApplyPatchAsActorOptions = {
   semantics?: PatchSemantics;
   strictParents?: boolean;
   jsonValidation?: JsonValidationMode;
+  signal?: AbortSignalLike;
 };
 
 /** Non-throwing result for internals-only `tryApplyPatchAsActor`. */
@@ -286,7 +295,14 @@ export type PatchErrorReason =
   | "DOT_GENERATION_EXHAUSTED"
   | "MAX_DEPTH_EXCEEDED"
   | "RESOURCE_BUDGET_EXCEEDED"
-  | "LINEAGE_MISMATCH";
+  | "LINEAGE_MISMATCH"
+  | "OPERATION_CANCELLED";
+
+/** Minimal structural signal accepted by cancellable APIs. Compatible with AbortSignal. */
+export interface AbortSignalLike {
+  readonly aborted: boolean;
+  readonly reason?: unknown;
+}
 
 /** Structured conflict payload used by non-throwing APIs. */
 export type ApplyError = {
@@ -353,6 +369,7 @@ export type ApplyPatchOptions = {
    * Defaults to `"none"` for backward compatibility.
    */
   jsonValidation?: JsonValidationMode;
+  signal?: AbortSignalLike;
 };
 
 /** Options for in-place patch application (`applyPatchInPlace` / `tryApplyPatchInPlace`). */
@@ -400,6 +417,7 @@ export type MergeStateOptions = {
    */
   requireSharedOrigin?: boolean;
   resourceBudget?: ResourceBudget;
+  signal?: AbortSignalLike;
 };
 
 /** Options for `mergeDoc`. */
@@ -417,10 +435,12 @@ export type MergeDocOptions = {
    */
   requireSharedOrigin?: boolean;
   resourceBudget?: ResourceBudget;
+  signal?: AbortSignalLike;
 };
 
 export interface DeserializeOptions {
   resourceBudget?: ResourceBudget;
+  signal?: AbortSignalLike;
 }
 
 /** Non-throwing result for `mergeDoc`. */
@@ -522,6 +542,7 @@ export type DiffOptions = {
    */
   jsonValidation?: JsonValidationMode;
   resourceBudget?: ResourceBudget;
+  signal?: AbortSignalLike;
 };
 
 /**

--- a/tests/cancellation.test.ts
+++ b/tests/cancellation.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  createState,
+  deserializeState,
+  diffJsonPatch,
+  mergeState,
+  OperationCancelledError,
+  serializeState,
+  tryApplyPatch,
+  tryDeserializeState,
+  tryMergeState,
+  type JsonValue,
+} from "../src/index";
+
+function abortedSignal(reason = "deadline exceeded"): AbortSignal {
+  return AbortSignal.abort(reason);
+}
+
+function makeLargeObject(size: number): Record<string, JsonValue> {
+  const value: Record<string, JsonValue> = {};
+  for (let index = 0; index < size; index++) {
+    value[`key${index}`] = index;
+  }
+  return value;
+}
+
+describe("operation cancellation", () => {
+  it("cancels JSON Patch diff work", () => {
+    expect(() =>
+      diffJsonPatch(makeLargeObject(100), makeLargeObject(100), {
+        signal: abortedSignal(),
+      }),
+    ).toThrow(OperationCancelledError);
+  });
+
+  it("returns a typed cancellation failure from patch application", () => {
+    const state = createState({ count: 0 }, { actor: "A" });
+    const result = tryApplyPatch(state, [{ op: "replace", path: "/count", value: 1 }], {
+      signal: abortedSignal("request closed"),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        ok: false,
+        code: 409,
+        reason: "OPERATION_CANCELLED",
+        message: "operation cancelled: request closed",
+      },
+    });
+  });
+
+  it("returns a typed cancellation failure from merge", () => {
+    const a = createState({ left: makeLargeObject(100) }, { actor: "A" });
+    const b = createState({ right: makeLargeObject(100) }, { actor: "B" });
+    const result = tryMergeState(a, b, { signal: abortedSignal() });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.reason).toBe("OPERATION_CANCELLED");
+    }
+  });
+
+  it("throws a merge error for cancelled throwing merges", () => {
+    const a = createState({ a: 1 }, { actor: "A" });
+    const b = createState({ b: 2 }, { actor: "B" });
+
+    expect(() => mergeState(a, b, { signal: abortedSignal() })).toThrow("operation cancelled");
+  });
+
+  it("returns a typed cancellation failure from deserialization", () => {
+    const state = createState(makeLargeObject(100), { actor: "A" });
+    const serialized = serializeState(state);
+    const result = tryDeserializeState(serialized, { signal: abortedSignal() });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.reason).toBe("OPERATION_CANCELLED");
+    }
+  });
+
+  it("throws a deserialize error for cancelled throwing deserialization", () => {
+    const state = createState({ a: 1 }, { actor: "A" });
+    const serialized = serializeState(state);
+
+    expect(() => deserializeState(serialized, { signal: abortedSignal() })).toThrow(
+      "operation cancelled",
+    );
+  });
+});

--- a/tests/cancellation.test.ts
+++ b/tests/cancellation.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it } from "bun:test";
 
 import {
   createState,
+  DeserializeError,
   deserializeState,
   diffJsonPatch,
   mergeState,
   OperationCancelledError,
   serializeState,
   tryApplyPatch,
+  tryApplyPatchInPlace,
   tryDeserializeState,
   tryMergeState,
+  toJson,
   type JsonValue,
 } from "../src/index";
 
@@ -23,6 +26,17 @@ function makeLargeObject(size: number): Record<string, JsonValue> {
     value[`key${index}`] = index;
   }
   return value;
+}
+
+function abortOnCheck(check: number, reason = "deadline exceeded"): AbortSignal {
+  let checks = 0;
+  return {
+    get aborted() {
+      checks += 1;
+      return checks >= check;
+    },
+    reason,
+  } as AbortSignal;
 }
 
 describe("operation cancellation", () => {
@@ -49,6 +63,32 @@ describe("operation cancellation", () => {
         message: "operation cancelled: request closed",
       },
     });
+  });
+
+  it("preserves partial in-place changes when non-atomic patching is cancelled", () => {
+    const state = createState({ count: 0, other: 0 }, { actor: "A" });
+    const result = tryApplyPatchInPlace(
+      state,
+      [
+        { op: "replace", path: "/count", value: 1 },
+        { op: "replace", path: "/other", value: 2 },
+      ],
+      {
+        atomic: false,
+        signal: abortOnCheck(3, "request closed"),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        ok: false,
+        code: 409,
+        reason: "OPERATION_CANCELLED",
+        message: "operation cancelled: request closed",
+      },
+    });
+    expect(toJson(state)).toEqual({ count: 1, other: 0 });
   });
 
   it("returns a typed cancellation failure from merge", () => {
@@ -85,7 +125,7 @@ describe("operation cancellation", () => {
     const serialized = serializeState(state);
 
     expect(() => deserializeState(serialized, { signal: abortedSignal() })).toThrow(
-      "operation cancelled",
+      DeserializeError,
     );
   });
 });


### PR DESCRIPTION
## Summary

Closes #149.

Adds optional AbortSignal-compatible cancellation support to expensive public APIs so callers can stop long-running work when a request is aborted or a deadline expires.

## Changes

- Added a structural `AbortSignalLike` option and exported `OperationCancelledError`.
- Threaded `options.signal` through expensive diff, patch, merge, and deserialize code paths.
- Added cancellation checks in explicit-stack traversals, array LCS loops, merge clone/representative-dot walks, and serialized payload validation.
- Returned typed `OPERATION_CANCELLED` failures from non-throwing patch, merge, and deserialize APIs.
- Documented immutable vs in-place cancellation behavior in the README.
- Added regression tests covering diff, patch, merge, and deserialization cancellation.
- Added a changeset for the public API addition.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`