### PR TITLE
[codex] Add CI performance gates

### DIFF
--- a/.changeset/perf-gates-ci.md
+++ b/.changeset/perf-gates-ci.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Add a dedicated CI performance gate for array diffing, merge traversal, and sequential patch application hot paths.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Run test suite
         run: bun test
+
+      - name: Run performance gate
+        run: bun run test:perf-gate

--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ operations already applied before cancellation remain applied. Non-throwing APIs
 `reason: "OPERATION_CANCELLED"` and throwing APIs throw their usual domain error wrappers where
 applicable.
 
+## Performance Gates
+
+CI runs `bun run test:perf-gate` as a fixed-size performance smoke test for
+the hottest paths: array diffing, merge traversal, and sequential patch
+application. These gates are intentionally smaller and more stable than the
+microbenchmarks in `bench/`; they fail with the measured median, sample list,
+threshold, and tuning variable so regressions are actionable.
+
+Run the gate locally before changing hot-path code:
+
+```bash
+bun run test:perf-gate
+```
+
+The default budgets are deliberately generous for shared CI. If a runner needs
+environment-specific tuning, set `PERF_GATE_ARRAY_DIFF_MS`,
+`PERF_GATE_MERGE_TRAVERSAL_MS`, `PERF_GATE_SEQUENTIAL_APPLY_MS`, or
+`PERF_GATE_RUNS`. Use the `bench:*` scripts for deeper investigation and only
+raise a gate after confirming the slowdown is intentional.
+
 ## Serialize / Restore State
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "bench:crdt-diff": "bun run bench/crdt-diff.microbench.ts",
     "bench:object-diff": "bun run bench/object-diff.microbench.ts",
     "bench:sequential": "bun run bench/sequential-apply.microbench.ts",
-    "test:perf-gate": "bun test tests/perf-gate.test.ts",
+    "test:perf-gate": "bun test ./tests/perf-gate.ts",
     "test:state-core": "bun test tests/state-core.test.ts",
     "test:patch-diff-doc": "bun test tests/patch-diff-doc.test.ts",
     "test:merge-compaction": "bun test tests/merge-compaction.test.ts",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bench:crdt-diff": "bun run bench/crdt-diff.microbench.ts",
     "bench:object-diff": "bun run bench/object-diff.microbench.ts",
     "bench:sequential": "bun run bench/sequential-apply.microbench.ts",
+    "test:perf-gate": "bun test tests/perf-gate.test.ts",
     "test:state-core": "bun test tests/state-core.test.ts",
     "test:patch-diff-doc": "bun test tests/patch-diff-doc.test.ts",
     "test:merge-compaction": "bun test tests/merge-compaction.test.ts",

--- a/tests/perf-gate.test.ts
+++ b/tests/perf-gate.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "bun:test";
+
+import type { JsonPatchOp, JsonValue } from "../src";
+
+import { applyPatch, createState, diffJsonPatch, toJson } from "../src";
+import { docFromJson, stringifyJsonPointer, tryMergeDoc } from "../src/internals";
+
+interface PerfGate {
+  readonly name: string;
+  readonly thresholdEnv: string;
+  readonly defaultThresholdMs: number;
+  readonly run: () => void;
+}
+
+interface PerfResult {
+  readonly name: string;
+  readonly medianMs: number;
+  readonly thresholdMs: number;
+  readonly samplesMs: readonly number[];
+}
+
+function parsePositiveNumberEnv(name: string, fallback: number): number {
+  const raw = Bun.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number, got '${raw}'`);
+  }
+
+  return parsed;
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor((sorted.length - 1) / 2)]!;
+}
+
+function measureGate(gate: PerfGate): PerfResult {
+  const runs = parsePositiveNumberEnv("PERF_GATE_RUNS", 5);
+  const thresholdMs = parsePositiveNumberEnv(gate.thresholdEnv, gate.defaultThresholdMs);
+
+  gate.run();
+
+  const samplesMs: number[] = [];
+  for (let i = 0; i < runs; i++) {
+    const startedAt = Bun.nanoseconds();
+    gate.run();
+    const endedAt = Bun.nanoseconds();
+    samplesMs.push((endedAt - startedAt) / 1_000_000);
+  }
+
+  return {
+    name: gate.name,
+    medianMs: median(samplesMs),
+    thresholdMs,
+    samplesMs,
+  };
+}
+
+function assertWithinGate(result: PerfResult, thresholdEnv: string): void {
+  expect(
+    result.medianMs,
+    [
+      `${result.name} exceeded its perf gate.`,
+      `median=${result.medianMs.toFixed(2)}ms threshold=${result.thresholdMs.toFixed(2)}ms`,
+      `samples=${result.samplesMs.map((sample) => sample.toFixed(2)).join(",")}ms`,
+      `If this is an intentional environment-specific adjustment, tune ${thresholdEnv}.`,
+    ].join(" "),
+  ).toBeLessThanOrEqual(result.thresholdMs);
+}
+
+function buildDeepObject(depth: number): JsonValue {
+  const leafKey = "a~b/c";
+  return Array.from({ length: depth }).reduce<JsonValue>((value) => ({ child: value }), {
+    [leafKey]: [1],
+  });
+}
+
+describe("CI performance gates", () => {
+  it("keeps array diffing within the fixed-size smoke budget", () => {
+    const baseArr = Array.from({ length: 1_500 }, (_, idx) => idx);
+    const nextArr = [...baseArr];
+    nextArr[750] = -1;
+    const base: JsonValue = { arr: baseArr };
+    const next: JsonValue = { arr: nextArr };
+    const expectedPatch: JsonPatchOp[] = [{ op: "replace", path: "/arr/750", value: -1 }];
+
+    const gate: PerfGate = {
+      name: "array diffing",
+      thresholdEnv: "PERF_GATE_ARRAY_DIFF_MS",
+      defaultThresholdMs: 250,
+      run: () => {
+        expect(diffJsonPatch(base, next)).toEqual(expectedPatch);
+      },
+    };
+
+    const result = measureGate(gate);
+    assertWithinGate(result, gate.thresholdEnv);
+  });
+
+  it("keeps merge traversal within the fixed-size smoke budget", () => {
+    const depth = 2_000;
+    const value = buildDeepObject(depth);
+    const expectedPath = stringifyJsonPointer([
+      ...Array.from({ length: depth }, () => "child"),
+      "a~b/c",
+    ]);
+
+    const gate: PerfGate = {
+      name: "merge traversal",
+      thresholdEnv: "PERF_GATE_MERGE_TRAVERSAL_MS",
+      defaultThresholdMs: 1_000,
+      run: () => {
+        const result = tryMergeDoc(
+          docFromJson(value, () => ({ actor: "A", ctr: 1 })),
+          docFromJson(value, () => ({ actor: "B", ctr: 1 })),
+        );
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.path).toBe(expectedPath);
+        }
+      },
+    };
+
+    const result = measureGate(gate);
+    assertWithinGate(result, gate.thresholdEnv);
+  });
+
+  it("keeps sequential patch application within the fixed-size smoke budget", () => {
+    const base = createState(
+      {
+        list: Array.from({ length: 500 }, (_, idx) => idx),
+      },
+      { actor: "perf-gate" },
+    );
+    const patch: JsonPatchOp[] = Array.from({ length: 400 }, (_, idx) => ({
+      op: "replace",
+      path: `/list/${idx}`,
+      value: idx + 1_000,
+    }));
+
+    const gate: PerfGate = {
+      name: "sequential patch application",
+      thresholdEnv: "PERF_GATE_SEQUENTIAL_APPLY_MS",
+      defaultThresholdMs: 500,
+      run: () => {
+        const next = applyPatch(base, patch, { semantics: "sequential" });
+        const json = toJson(next) as { list: number[] };
+
+        expect(json.list[0]).toBe(1_000);
+        expect(json.list[399]).toBe(1_399);
+        expect(json.list[499]).toBe(499);
+      },
+    };
+
+    const result = measureGate(gate);
+    assertWithinGate(result, gate.thresholdEnv);
+  });
+});

--- a/tests/perf-gate.ts
+++ b/tests/perf-gate.ts
@@ -35,7 +35,9 @@ function parsePositiveNumberEnv(name: string, fallback: number): number {
 
 function median(values: readonly number[]): number {
   const sorted = [...values].sort((left, right) => left - right);
-  return sorted[Math.floor((sorted.length - 1) / 2)]!;
+  const mid = Math.floor(sorted.length / 2);
+
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
 }
 
 function measureGate(gate: PerfGate): PerfResult {


### PR DESCRIPTION
## Summary

Adds a dedicated `test:perf-gate` script that runs fixed-size performance smoke tests for the hot paths called out in #151:

- array diffing
- merge traversal
- sequential patch application

The gate measures median runtime across repeated samples, keeps the default budgets intentionally generous for shared CI, and emits actionable failure messages with the measured median, sample list, threshold, and tuning environment variable.

## Why

The repository already has targeted performance regression tests and deeper microbenchmarks, but pull request CI did not expose a named perf signal for these hot paths. This adds a stable CI check that catches material slowdowns without making the full benchmark suite part of every PR.

## Contributor Impact

`bun run test:perf-gate` is now documented in the README for hot-path changes. The docs also describe the tuning variables:

- `PERF_GATE_ARRAY_DIFF_MS`
- `PERF_GATE_MERGE_TRAVERSAL_MS`
- `PERF_GATE_SEQUENTIAL_APPLY_MS`
- `PERF_GATE_RUNS`

## Validation

- `bun run test:perf-gate`
- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun fmt:check`
- `bun run test`

Closes #151