### PR TITLE
fix: preserve empty container replacements during merge

### DIFF
--- a/.changeset/dirty-forks-buy.md
+++ b/.changeset/dirty-forks-buy.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Preserve empty object and array replacements during merge by recording container replacement dots and using them during conflict resolution.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -107,7 +107,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
 
   if (path.length === 0) {
     if (head.root.kind !== "seq") {
-      head.root = newSeq(dotForCreate);
+      head.root = newSeq();
     }
     return head.root as RgaSeq;
   }
@@ -116,7 +116,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
     const seg = path[i]!;
 
     if (cur.kind !== "obj") {
-      const replacement = newObj(dotForCreate);
+      const replacement = newObj();
 
       if (parent && parentKey !== null) {
         objSet(parent, parentKey, replacement, dotForCreate);
@@ -132,7 +132,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
 
     if (i === path.length - 1) {
       if (!ent || ent.node.kind !== "seq") {
-        const seq = newSeq(dotForCreate);
+        const seq = newSeq();
         objSet(obj, seg, seq, dotForCreate);
         return seq;
       }
@@ -141,7 +141,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
     }
 
     if (!ent || ent.node.kind !== "obj") {
-      const child = newObj(dotForCreate);
+      const child = newObj();
       objSet(obj, seg, child, dotForCreate);
       parent = obj;
       parentKey = seg;
@@ -155,7 +155,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
 
   // Unreachable, but TypeScript needs a return.
   if (head.root.kind !== "seq") {
-    head.root = newSeq(dotForCreate);
+    head.root = newSeq();
   }
 
   return head.root as RgaSeq;
@@ -276,6 +276,12 @@ function deepNodeFromJsonWithDepth(value: JsonValue, dot: Dot, depth: number): N
   return obj;
 }
 
+/**
+ * Convert JSON into a node whose root is represented by `rootDot`.
+ *
+ * Callers that already allocated a mutation dot must pass it explicitly so the
+ * document state represents that event without consuming an extra clock tick.
+ */
 function nodeFromJson(value: JsonValue, nextDot: () => Dot, rootDot = nextDot()): Node {
   if (isJsonPrimitive(value)) {
     return newReg(value, rootDot);

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -57,11 +57,12 @@ import {
  */
 export function docFromJson(value: JsonValue, nextDot: () => Dot): Doc {
   const vv = Object.create(null) as VersionVector;
-  const root = nodeFromJson(value, () => {
+  const observedNextDot = () => {
     const dot = nextDot();
     observeVersionVectorDot(vv, dot);
     return dot;
-  });
+  };
+  const root = nodeFromJson(value, observedNextDot, observedNextDot());
   const doc = { root };
   writeCachedObservedVersionVector(doc, vv);
   return doc;
@@ -278,11 +279,8 @@ function deepNodeFromJsonWithDepth(value: JsonValue, dot: Dot, depth: number): N
 
 /**
  * Convert JSON into a node whose root is represented by `rootDot`.
- *
- * Callers that already allocated a mutation dot must pass it explicitly so the
- * document state represents that event without consuming an extra clock tick.
  */
-function nodeFromJson(value: JsonValue, nextDot: () => Dot, rootDot = nextDot()): Node {
+function nodeFromJson(value: JsonValue, nextDot: () => Dot, rootDot: Dot): Node {
   if (isJsonPrimitive(value)) {
     return newReg(value, rootDot);
   }
@@ -627,7 +625,7 @@ function applyObjSet(
   newDot: () => Dot,
 ): ApplyResult | null {
   if (it.path.length === 0 && it.key === ROOT_KEY) {
-    head.root = nodeFromJson(it.value, newDot);
+    head.root = nodeFromJson(it.value, newDot, newDot());
     return null;
   }
 

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -107,7 +107,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
 
   if (path.length === 0) {
     if (head.root.kind !== "seq") {
-      head.root = newSeq();
+      head.root = newSeq(dotForCreate);
     }
     return head.root as RgaSeq;
   }
@@ -116,7 +116,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
     const seg = path[i]!;
 
     if (cur.kind !== "obj") {
-      const replacement = newObj();
+      const replacement = newObj(dotForCreate);
 
       if (parent && parentKey !== null) {
         objSet(parent, parentKey, replacement, dotForCreate);
@@ -132,7 +132,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
 
     if (i === path.length - 1) {
       if (!ent || ent.node.kind !== "seq") {
-        const seq = newSeq();
+        const seq = newSeq(dotForCreate);
         objSet(obj, seg, seq, dotForCreate);
         return seq;
       }
@@ -141,7 +141,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
     }
 
     if (!ent || ent.node.kind !== "obj") {
-      const child = newObj();
+      const child = newObj(dotForCreate);
       objSet(obj, seg, child, dotForCreate);
       parent = obj;
       parentKey = seg;
@@ -155,7 +155,7 @@ function ensureSeqAtPath(head: Doc, path: string[], dotForCreate: Dot): RgaSeq {
 
   // Unreachable, but TypeScript needs a return.
   if (head.root.kind !== "seq") {
-    head.root = newSeq();
+    head.root = newSeq(dotForCreate);
   }
 
   return head.root as RgaSeq;
@@ -256,7 +256,7 @@ function deepNodeFromJsonWithDepth(value: JsonValue, dot: Dot, depth: number): N
     return newReg(value, dot);
   }
   if (Array.isArray(value)) {
-    const seq = newSeq();
+    const seq = newSeq(dot);
     let prev = HEAD;
     // insert in order with synthetic dots derived from dot (not great). In production use fresh dots per element.
     // For now, keep it simple: all children get the same dot ordering via ctr offset.
@@ -269,19 +269,19 @@ function deepNodeFromJsonWithDepth(value: JsonValue, dot: Dot, depth: number): N
     }
     return seq;
   }
-  const obj = newObj();
+  const obj = newObj(dot);
   for (const [k, v] of Object.entries(value)) {
     objSet(obj, k, deepNodeFromJsonWithDepth(v, dot, depth + 1), dot);
   }
   return obj;
 }
 
-function nodeFromJson(value: JsonValue, nextDot: () => Dot): Node {
+function nodeFromJson(value: JsonValue, nextDot: () => Dot, rootDot = nextDot()): Node {
   if (isJsonPrimitive(value)) {
-    return newReg(value, nextDot());
+    return newReg(value, rootDot);
   }
 
-  const root = Array.isArray(value) ? newSeq() : newObj();
+  const root = Array.isArray(value) ? newSeq(rootDot) : newObj(rootDot);
   type ObjFrame = {
     kind: "obj";
     depth: number;
@@ -333,12 +333,12 @@ function nodeFromJson(value: JsonValue, nextDot: () => Dot): Node {
 
       const entryDot = nextDot();
       if (isJsonPrimitive(childValue)) {
-        objSet(frame.target, key, newReg(childValue, nextDot()), entryDot);
+        objSet(frame.target, key, newReg(childValue, entryDot), entryDot);
         continue;
       }
 
       if (Array.isArray(childValue)) {
-        const childSeq = newSeq();
+        const childSeq = newSeq(entryDot);
         objSet(frame.target, key, childSeq, entryDot);
         stack.push({
           kind: "seq",
@@ -351,7 +351,7 @@ function nodeFromJson(value: JsonValue, nextDot: () => Dot): Node {
         continue;
       }
 
-      const childObj = newObj();
+      const childObj = newObj(entryDot);
       objSet(frame.target, key, childObj, entryDot);
       stack.push({
         kind: "obj",
@@ -376,13 +376,13 @@ function nodeFromJson(value: JsonValue, nextDot: () => Dot): Node {
     const id = dotToElemId(insDot);
 
     if (isJsonPrimitive(childValue)) {
-      rgaInsertAfter(frame.target, frame.prev, id, insDot, newReg(childValue, nextDot()));
+      rgaInsertAfter(frame.target, frame.prev, id, insDot, newReg(childValue, insDot));
       frame.prev = id;
       continue;
     }
 
     if (Array.isArray(childValue)) {
-      const childSeq = newSeq();
+      const childSeq = newSeq(insDot);
       rgaInsertAfter(frame.target, frame.prev, id, insDot, childSeq);
       frame.prev = id;
       stack.push({
@@ -396,7 +396,7 @@ function nodeFromJson(value: JsonValue, nextDot: () => Dot): Node {
       continue;
     }
 
-    const childObj = newObj();
+    const childObj = newObj(insDot);
     rgaInsertAfter(frame.target, frame.prev, id, insDot, childObj);
     frame.prev = id;
     stack.push({
@@ -451,6 +451,7 @@ function cloneNodeAtDepth(node: Node, depth: number): Node {
 
     return {
       kind: "obj",
+      dot: node.dot ? { actor: node.dot.actor, ctr: node.dot.ctr } : undefined,
       entries,
       tombstone,
     };
@@ -468,7 +469,11 @@ function cloneNodeAtDepth(node: Node, depth: number): Node {
     });
   }
 
-  return { kind: "seq", elems };
+  return {
+    kind: "seq",
+    dot: node.dot ? { actor: node.dot.actor, ctr: node.dot.ctr } : undefined,
+    elems,
+  };
 }
 
 function isJsonPrimitive(value: JsonValue): value is null | string | number | boolean {
@@ -643,7 +648,7 @@ function applyObjSet(
 
   const d = newDot();
   const parentObj = parentRes.obj;
-  objSet(parentObj, it.key, nodeFromJson(it.value, newDot), d);
+  objSet(parentObj, it.key, nodeFromJson(it.value, newDot, d), d);
   return null;
 }
 
@@ -734,7 +739,7 @@ function applyArrInsert(
 
       const d = dotRes.dot;
       const id = dotToElemId(d);
-      rgaInsertAfter(headSeq, prev, id, d, nodeFromJson(it.value, newDot));
+      rgaInsertAfter(headSeq, prev, id, d, nodeFromJson(it.value, newDot, d));
       return null;
     }
 
@@ -775,7 +780,7 @@ function applyArrInsert(
 
   const d = dotRes.dot;
   const id = dotToElemId(d);
-  rgaInsertAfter(headSeq, prev, id, d, nodeFromJson(it.value, newDot));
+  rgaInsertAfter(headSeq, prev, id, d, nodeFromJson(it.value, newDot, d));
   if (baseSeq === headSeq) {
     baseIndex.insertAt(idx, id);
   }
@@ -927,7 +932,7 @@ function applyArrReplace(
     };
   }
 
-  e.value = nodeFromJson(it.value, newDot);
+  e.value = nodeFromJson(it.value, newDot, _d);
 
   return null;
 }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -370,6 +370,9 @@ function repDot(node: Node, signal?: MergeDocOptions["signal"]): Dot {
         }
         break;
       case "obj":
+        if (frame.node.dot && compareDot(frame.node.dot, best) > 0) {
+          best = frame.node.dot;
+        }
         for (const entry of frame.node.entries.values()) {
           if (compareDot(entry.dot, best) > 0) {
             best = entry.dot;
@@ -384,6 +387,9 @@ function repDot(node: Node, signal?: MergeDocOptions["signal"]): Dot {
         }
         break;
       case "seq":
+        if (frame.node.dot && compareDot(frame.node.dot, best) > 0) {
+          best = frame.node.dot;
+        }
         for (const elem of frame.node.elems.values()) {
           if (compareDot(elem.insDot, best) > 0) {
             best = elem.insDot;
@@ -447,7 +453,10 @@ function mergeObj(
   assertTraversalDepth(depth);
   const entries = new Map<string, { node: Node; dot: Dot }>();
   const tombstone = new Map<string, Dot>();
-  let maxObservedCtr = 0;
+  let maxObservedCtr = maxObservedCtrForDot(
+    compareOptionalDot(a.dot, b.dot) >= 0 ? a.dot : b.dot,
+    config.actor,
+  );
 
   // Merge tombstones: max dot per key.
   const allTombKeys = new Set([...a.tombstone.keys(), ...b.tombstone.keys()]);
@@ -492,10 +501,16 @@ function mergeObj(
       merged = { node: mergedNode.node, dot };
       mergedNodeMaxObservedCtr = mergedNode.maxObservedCtr;
     } else if (ea) {
+      if (b.dot && compareDot(b.dot, ea.dot) >= 0) {
+        continue;
+      }
       const cloned = cloneNodeShallow(ea.node, depth + 1, config.actor, config.signal);
       merged = { node: cloned.node, dot: { ...ea.dot } };
       mergedNodeMaxObservedCtr = cloned.maxObservedCtr;
     } else {
+      if (a.dot && compareDot(a.dot, eb!.dot) >= 0) {
+        continue;
+      }
       const cloned = cloneNodeShallow(eb!.node, depth + 1, config.actor, config.signal);
       merged = { node: cloned.node, dot: { ...eb!.dot } };
       mergedNodeMaxObservedCtr = cloned.maxObservedCtr;
@@ -515,7 +530,8 @@ function mergeObj(
     );
   }
 
-  return { node: { kind: "obj", entries, tombstone }, maxObservedCtr };
+  const dot = mergeOptionalDot(a.dot, b.dot);
+  return { node: { kind: "obj", dot, entries, tombstone }, maxObservedCtr };
 }
 
 function mergeSeq(
@@ -551,7 +567,10 @@ function mergeSeq(
   }
 
   const elems = new Map<string, RgaElem>();
-  let maxObservedCtr = 0;
+  let maxObservedCtr = maxObservedCtrForDot(
+    compareOptionalDot(a.dot, b.dot) >= 0 ? a.dot : b.dot,
+    config.actor,
+  );
 
   // Union by element ID.
   const allIds = new Set([...a.elems.keys(), ...b.elems.keys()]);
@@ -598,17 +617,24 @@ function mergeSeq(
         maxObservedCtrForDot(mergedDeleteDot, config.actor),
       );
     } else if (ea) {
+      if (b.dot && compareDot(b.dot, ea.insDot) >= 0) {
+        continue;
+      }
       const cloned = cloneElem(ea, depth + 1, config.actor, config.signal);
       elems.set(id, cloned.elem);
       maxObservedCtr = Math.max(maxObservedCtr, cloned.maxObservedCtr);
     } else {
+      if (a.dot && compareDot(a.dot, eb!.insDot) >= 0) {
+        continue;
+      }
       const cloned = cloneElem(eb!, depth + 1, config.actor, config.signal);
       elems.set(id, cloned.elem);
       maxObservedCtr = Math.max(maxObservedCtr, cloned.maxObservedCtr);
     }
   }
 
-  return { node: { kind: "seq", elems }, maxObservedCtr };
+  const dot = mergeOptionalDot(a.dot, b.dot);
+  return { node: { kind: "seq", dot, elems }, maxObservedCtr };
 }
 
 function sameDot(a: Dot, b: Dot): boolean {
@@ -657,6 +683,38 @@ function mergeDeleteDot(a?: Dot, b?: Dot): Dot | undefined {
   return undefined;
 }
 
+function mergeOptionalDot(a?: Dot, b?: Dot): Dot | undefined {
+  if (a && b) {
+    return compareDot(a, b) >= 0 ? { ...a } : { ...b };
+  }
+
+  if (a) {
+    return { ...a };
+  }
+
+  if (b) {
+    return { ...b };
+  }
+
+  return undefined;
+}
+
+function compareOptionalDot(a?: Dot, b?: Dot): number {
+  if (a && b) {
+    return compareDot(a, b);
+  }
+
+  if (a) {
+    return 1;
+  }
+
+  if (b) {
+    return -1;
+  }
+
+  return 0;
+}
+
 function cloneNodeShallow(
   node: Node,
   depth: number,
@@ -673,7 +731,7 @@ function cloneNodeShallow(
       };
     case "obj": {
       const entries = new Map<string, { node: Node; dot: Dot }>();
-      let maxObservedCtr = 0;
+      let maxObservedCtr = maxObservedCtrForDot(node.dot, actor);
       for (const [k, v] of node.entries) {
         throwIfAborted(signal);
         const cloned = cloneNodeShallow(v.node, depth + 1, actor, signal);
@@ -690,18 +748,24 @@ function cloneNodeShallow(
         tombstone.set(k, { ...d });
         maxObservedCtr = Math.max(maxObservedCtr, maxObservedCtrForDot(d, actor));
       }
-      return { node: { kind: "obj", entries, tombstone }, maxObservedCtr };
+      return {
+        node: { kind: "obj", dot: node.dot ? { ...node.dot } : undefined, entries, tombstone },
+        maxObservedCtr,
+      };
     }
     case "seq": {
       const elems = new Map<string, RgaElem>();
-      let maxObservedCtr = 0;
+      let maxObservedCtr = maxObservedCtrForDot(node.dot, actor);
       for (const [id, e] of node.elems) {
         throwIfAborted(signal);
         const cloned = cloneElem(e, depth + 1, actor, signal);
         elems.set(id, cloned.elem);
         maxObservedCtr = Math.max(maxObservedCtr, cloned.maxObservedCtr);
       }
-      return { node: { kind: "seq", elems }, maxObservedCtr };
+      return {
+        node: { kind: "seq", dot: node.dot ? { ...node.dot } : undefined, elems },
+        maxObservedCtr,
+      };
     }
   }
 }

--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -2,12 +2,12 @@ import type { Dot, JsonValue, LwwReg, Node, ObjNode, RgaSeq } from "./types";
 
 import { compareDot } from "./dot";
 
-export function newObj(): ObjNode {
-  return { kind: "obj", entries: new Map(), tombstone: new Map() };
+export function newObj(dot?: Dot): ObjNode {
+  return { kind: "obj", dot, entries: new Map(), tombstone: new Map() };
 }
 
-export function newSeq(): RgaSeq {
-  return { kind: "seq", elems: new Map() };
+export function newSeq(dot?: Dot): RgaSeq {
+  return { kind: "seq", dot, elems: new Map() };
 }
 
 export function newReg(value: JsonValue, dot: Dot): LwwReg {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -258,7 +258,12 @@ function serializeNode(node: Doc["root"]): SerializedNode {
       setSerializedRecordValue(tombstone, k, { actor: d.actor, ctr: d.ctr });
     }
 
-    return { kind: "obj", entries, tombstone };
+    return {
+      kind: "obj",
+      dot: node.dot ? { actor: node.dot.actor, ctr: node.dot.ctr } : undefined,
+      entries,
+      tombstone,
+    };
   }
 
   const elems = createSerializedRecord<SerializedRgaElem>();
@@ -277,7 +282,11 @@ function serializeNode(node: Doc["root"]): SerializedNode {
     setSerializedRecordValue(elems, id, serializedElem);
   }
 
-  return { kind: "seq", elems };
+  return {
+    kind: "seq",
+    dot: node.dot ? { actor: node.dot.actor, ctr: node.dot.ctr } : undefined,
+    elems,
+  };
 }
 
 function readSerializedDocEnvelope(data: SerializedDoc): Record<string, unknown> {
@@ -344,6 +353,11 @@ function deserializeNode(
   }
 
   if (kind === "obj") {
+    const containerDot =
+      "dot" in raw && raw.dot !== undefined ? readDot(raw.dot, `${path}/dot`) : undefined;
+    if (observed && containerDot) {
+      observeVersionVectorDot(observed, containerDot);
+    }
     const entriesRaw = asRecord(raw.entries, `${path}/entries`);
     const tombstoneRaw = asRecord(raw.tombstone, `${path}/tombstone`);
     budgetMeter?.count("objectEntries", Object.keys(entriesRaw).length, `${path}/entries`);
@@ -383,13 +397,18 @@ function deserializeNode(
       tombstone.set(k, dot);
     }
 
-    return { kind: "obj", entries, tombstone };
+    return { kind: "obj", dot: containerDot, entries, tombstone };
   }
 
   if (kind !== "seq") {
     fail("INVALID_SERIALIZED_SHAPE", `${path}/kind`, `unsupported node kind '${kind}'`);
   }
 
+  const containerDot =
+    "dot" in raw && raw.dot !== undefined ? readDot(raw.dot, `${path}/dot`) : undefined;
+  if (observed && containerDot) {
+    observeVersionVectorDot(observed, containerDot);
+  }
   const elemsRaw = asRecord(raw.elems, `${path}/elems`);
   budgetMeter?.count("sequenceElements", Object.keys(elemsRaw).length, `${path}/elems`);
   budgetMeter?.count("serializedElements", Object.keys(elemsRaw).length, `${path}/elems`);
@@ -474,7 +493,7 @@ function deserializeNode(
 
   assertAcyclicRgaPredecessors(elems, path);
 
-  return { kind: "seq", elems };
+  return { kind: "seq", dot: containerDot, elems };
 }
 
 function validateSerializedNode(
@@ -504,6 +523,9 @@ function validateSerializedNode(
   }
 
   if (kind === "obj") {
+    if ("dot" in raw && raw.dot !== undefined) {
+      readDot(raw.dot, `${path}/dot`);
+    }
     const entriesRaw = asRecord(raw.entries, `${path}/entries`);
     const tombstoneRaw = asRecord(raw.tombstone, `${path}/tombstone`);
     budgetMeter?.count("objectEntries", Object.keys(entriesRaw).length, `${path}/entries`);
@@ -531,6 +553,9 @@ function validateSerializedNode(
     fail("INVALID_SERIALIZED_SHAPE", `${path}/kind`, `unsupported node kind '${kind}'`);
   }
 
+  if ("dot" in raw && raw.dot !== undefined) {
+    readDot(raw.dot, `${path}/dot`);
+  }
   const elemsRaw = asRecord(raw.elems, `${path}/elems`);
   budgetMeter?.count("sequenceElements", Object.keys(elemsRaw).length, `${path}/elems`);
   budgetMeter?.count("serializedElements", Object.keys(elemsRaw).length, `${path}/elems`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,8 @@ export type RgaElem = {
 /** Replicated Growable Array: an ordered sequence CRDT with tombstones. */
 export type RgaSeq = {
   kind: "seq";
+  /** Dot for the event that created or replaced this container node. */
+  dot?: Dot;
   elems: Map<ElemId, RgaElem>;
 };
 
@@ -79,6 +81,8 @@ export type ObjEntry = { node: Node; dot: Dot };
 /** Delete-wins object CRDT: a map of string keys to child nodes. */
 export type ObjNode = {
   kind: "obj";
+  /** Dot for the event that created or replaced this container node. */
+  dot?: Dot;
   entries: Map<string, ObjEntry>;
   /** Latest delete dot per key (delete-wins semantics). */
   tombstone: Map<string, Dot>;
@@ -106,10 +110,11 @@ export type SerializedNode =
   | { kind: "lww"; value: JsonValue; dot: Dot }
   | {
       kind: "obj";
+      dot?: Dot;
       entries: Record<string, { node: SerializedNode; dot: Dot }>;
       tombstone: Record<string, Dot>;
     }
-  | { kind: "seq"; elems: Record<string, SerializedRgaElem> };
+  | { kind: "seq"; dot?: Dot; elems: Record<string, SerializedRgaElem> };
 
 /** Versioned JSON-serializable form of a CRDT document. */
 export interface SerializedDocV1 {

--- a/src/version-vector.ts
+++ b/src/version-vector.ts
@@ -82,6 +82,9 @@ export function observedVersionVector(target: Doc | CrdtState): VersionVector {
     }
 
     if (frame.node.kind === "obj") {
+      if (frame.node.dot) {
+        observeVersionVectorDot(vv, frame.node.dot);
+      }
       for (const entry of frame.node.entries.values()) {
         observeVersionVectorDot(vv, entry.dot);
         stack.push({ node: entry.node, depth: frame.depth + 1 });
@@ -93,6 +96,9 @@ export function observedVersionVector(target: Doc | CrdtState): VersionVector {
       continue;
     }
 
+    if (frame.node.dot) {
+      observeVersionVectorDot(vv, frame.node.dot);
+    }
     for (const elem of frame.node.elems.values()) {
       observeVersionVectorDot(vv, elem.insDot);
       if (elem.delDot) {

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -589,6 +589,25 @@ describe("mergeState", () => {
     }
   });
 
+  it("resolves two-sided concurrent container replacements by representative dot", () => {
+    const origin = createState({ other: 0, x: 1 }, { actor: "O" });
+    const emptyReplacement = applyPatch(forkState(origin, "Z"), [
+      { op: "replace", path: "/other", value: 1 },
+      { op: "replace", path: "/x", value: {} },
+    ]);
+    const nonEmptyReplacement = applyPatch(forkState(origin, "A"), [
+      { op: "replace", path: "/x", value: { y: 1 } },
+    ]);
+    const expected = { other: 1, x: {} };
+
+    expect(toJson(mergeState(emptyReplacement, nonEmptyReplacement, { actor: "Z" }))).toEqual(
+      expected,
+    );
+    expect(toJson(mergeState(nonEmptyReplacement, emptyReplacement, { actor: "A" }))).toEqual(
+      expected,
+    );
+  });
+
   it("preserves array-element replacement with empty containers across merge", () => {
     for (const value of [{}, []] as const) {
       const origin = createState({ list: [1] }, { actor: "O" });

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -62,6 +62,7 @@ import {
   tryMergeDoc,
   tryMergeState,
   toJson,
+  withLegacyMissingArrayParents,
   vvHasDot,
   vvMerge,
   type Dot,
@@ -601,6 +602,36 @@ describe("mergeState", () => {
       expect(toJson(mergeState(replacement, peer, { actor: "A" }))).toEqual(expected);
       expect(toJson(mergeState(peer, replacement, { actor: "B" }))).toEqual(expected);
     }
+  });
+
+  it("keeps peer entries when legacy array parent creation builds structural containers", () => {
+    const origin = docFromJsonWithDot({}, dot("O", 1));
+    const legacyArrayInsert = cloneDoc(origin);
+    const peerObjectWrite = cloneDoc(origin);
+
+    const insertResult = applyIntentsToCrdt(
+      origin,
+      legacyArrayInsert,
+      [{ t: "ArrInsert", path: ["a", "b"], index: 0, value: "x" }],
+      newDotGen("A", 10),
+      "head",
+      undefined,
+      withLegacyMissingArrayParents(),
+    );
+    expect(insertResult).toEqual({ ok: true });
+
+    const objectResult = applyIntentsToCrdt(
+      origin,
+      peerObjectWrite,
+      [{ t: "ObjSet", path: [], key: "a", value: { c: 1 } }],
+      newDotGen("B", 1),
+      "head",
+    );
+    expect(objectResult).toEqual({ ok: true });
+
+    const merged = mergeDoc(legacyArrayInsert, peerObjectWrite);
+
+    expect(materialize(merged.root)).toEqual({ a: { b: ["x"], c: 1 } });
   });
 
   it("merges two states and keeps the local actor by default", () => {

--- a/tests/merge-compaction.test.ts
+++ b/tests/merge-compaction.test.ts
@@ -561,6 +561,48 @@ describe("mergeDoc", () => {
 });
 
 describe("mergeState", () => {
+  it("preserves root replacement with empty containers across merge", () => {
+    for (const value of [{}, []] as const) {
+      const origin = createState({ x: 1 }, { actor: "O" });
+      const replacement = applyPatch(forkState(origin, "A"), [{ op: "replace", path: "", value }]);
+      const peer = forkState(origin, "B");
+
+      expect(toJson(replacement)).toEqual(value);
+      expect(toJson(mergeState(replacement, peer, { actor: "A" }))).toEqual(value);
+      expect(toJson(mergeState(peer, replacement, { actor: "B" }))).toEqual(value);
+    }
+  });
+
+  it("preserves object-key replacement with empty containers across merge", () => {
+    for (const value of [{}, []] as const) {
+      const origin = createState({ x: 1 }, { actor: "O" });
+      const replacement = applyPatch(forkState(origin, "A"), [
+        { op: "replace", path: "/x", value },
+      ]);
+      const peer = forkState(origin, "B");
+      const expected = { x: value };
+
+      expect(toJson(replacement)).toEqual(expected);
+      expect(toJson(mergeState(replacement, peer, { actor: "A" }))).toEqual(expected);
+      expect(toJson(mergeState(peer, replacement, { actor: "B" }))).toEqual(expected);
+    }
+  });
+
+  it("preserves array-element replacement with empty containers across merge", () => {
+    for (const value of [{}, []] as const) {
+      const origin = createState({ list: [1] }, { actor: "O" });
+      const replacement = applyPatch(forkState(origin, "A"), [
+        { op: "replace", path: "/list/0", value },
+      ]);
+      const peer = forkState(origin, "B");
+      const expected = { list: [value] };
+
+      expect(toJson(replacement)).toEqual(expected);
+      expect(toJson(mergeState(replacement, peer, { actor: "A" }))).toEqual(expected);
+      expect(toJson(mergeState(peer, replacement, { actor: "B" }))).toEqual(expected);
+    }
+  });
+
   it("merges two states and keeps the local actor by default", () => {
     const a = createState({ x: 1 }, { actor: "A" });
     const b = createState({ y: 2 }, { actor: "B" });
@@ -737,7 +779,7 @@ describe("mergeState", () => {
     }
 
     expect(next.doc.root.entries.get("x")?.dot).toEqual({ actor: "A", ctr: 5 });
-    expect(next.clock.ctr).toBe(6);
+    expect(next.clock.ctr).toBe(5);
   });
 });
 

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -213,7 +213,7 @@ describe("dots and version vectors", () => {
     );
 
     expect(result.ok).toBe(true);
-    expect(observedVersionVector(doc)).toEqual({ A: 2, B: 10 });
+    expect(observedVersionVector(doc)).toEqual({ A: 1, B: 10 });
   });
 
   it("supports public merge, intersection, and coverage checks for version vectors", () => {
@@ -885,11 +885,11 @@ describe("clock and state", () => {
       throw new Error("Expected list sequence and x entry");
     }
 
-    const deletedElem = listNode.elems.get("A:2");
+    const deletedElem = listNode.elems.get("A:3");
     expect(deletedElem?.delDot).toEqual({ actor: "A", ctr: 4 });
     expect(xEntry.dot).toEqual({ actor: "A", ctr: 5 });
-    expect(resumed.state.clock.ctr).toBe(6);
-    expect(resumed.vv["A"]).toBe(6);
+    expect(resumed.state.clock.ctr).toBe(5);
+    expect(resumed.vv["A"]).toBe(5);
   });
 
   it("exposes a non-throwing applyPatchAsActor helper", () => {
@@ -1858,7 +1858,7 @@ describe("serialization", () => {
     }
 
     expect(next.doc.root.entries.get("x")?.dot).toEqual({ actor: "A", ctr: 5 });
-    expect(next.clock.ctr).toBe(6);
+    expect(next.clock.ctr).toBe(5);
   });
 
   it("rejects sequence elements whose key does not match element id", () => {


### PR DESCRIPTION
## Summary

Fixes #163.

This change preserves causal metadata for replacements with empty object and array containers so merge conflict resolution can compare the replacement event instead of falling back to an empty child set.

## Changes

- Add optional container dots to object and sequence CRDT nodes.
- Seed container dots from root replacement, object assignment, array insertion, and array replacement events.
- Include container dots in representative-dot merge resolution, observed version vectors, clone, serialization, deserialization, and validation.
- Treat newer container replacement dots as barriers against older one-sided object entries and sequence elements during same-kind merges.
- Reuse represented mutation dots for patch-created values to avoid advancing clocks with ghost dots.
- Add regression tests for root, object-key, and array-element replacement to `{}` and `[]` across merge.
- Add a patch changeset.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun run test`