### PR TITLE
[codex] Fix sequential move validation before mutation

### DIFF
--- a/.changeset/sharp-pumas-move.md
+++ b/.changeset/sharp-pumas-move.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Reject sequential JSON Patch moves into descendant targets before mutating state and treat validated self-moves as metadata-preserving no-ops.

--- a/src/state.ts
+++ b/src/state.ts
@@ -393,6 +393,22 @@ function applyPatchOpSequential(
   session: SequentialApplySession,
 ): ApplyResult {
   if (op.op === "move") {
+    const movePaths = parseMovePointerPaths(op, opIndex, session.pointerCache);
+    if (!movePaths.ok) {
+      return movePaths;
+    }
+
+    if (isStrictDescendantPath(movePaths.fromPath, movePaths.toPath)) {
+      return {
+        ok: false,
+        code: 409,
+        reason: "INVALID_MOVE",
+        message: `cannot move a value into one of its descendants at ${op.path}`,
+        path: op.path,
+        opIndex,
+      };
+    }
+
     const fromResolved = resolveValueAtPointerInDoc(
       baseDoc,
       op.from,
@@ -401,6 +417,10 @@ function applyPatchOpSequential(
     );
     if (!fromResolved.ok) {
       return fromResolved;
+    }
+
+    if (isSamePath(movePaths.fromPath, movePaths.toPath)) {
+      return { ok: true };
     }
 
     const fromValue = structuredClone(fromResolved.value);
@@ -497,6 +517,36 @@ function applyPatchOpSequential(
     opIndex,
     session,
   );
+}
+
+function parseMovePointerPaths(
+  op: Extract<JsonPatchOp, { op: "move" }>,
+  opIndex: number,
+  pointerCache: Map<string, string[]>,
+): { ok: true; fromPath: string[]; toPath: string[] } | ApplyError {
+  const fromPath = parseMovePointerPath(op.from, opIndex, pointerCache);
+  if (!fromPath.ok) {
+    return fromPath;
+  }
+
+  const toPath = parseMovePointerPath(op.path, opIndex, pointerCache);
+  if (!toPath.ok) {
+    return toPath;
+  }
+
+  return { ok: true, fromPath: fromPath.path, toPath: toPath.path };
+}
+
+function parseMovePointerPath(
+  pointer: string,
+  opIndex: number,
+  pointerCache: Map<string, string[]>,
+): { ok: true; path: string[] } | ApplyError {
+  try {
+    return { ok: true, path: parsePointerWithCache(pointer, pointerCache) };
+  } catch (error) {
+    return toPointerParseApplyError(error, pointer, opIndex);
+  }
 }
 
 function applySinglePatchOpSequentialStep(
@@ -1106,4 +1156,32 @@ function toPointerParseApplyError(error: unknown, pointer: string, opIndex: numb
     path: pointer,
     opIndex,
   };
+}
+
+function isStrictDescendantPath(from: string[], to: string[]): boolean {
+  if (to.length <= from.length) {
+    return false;
+  }
+
+  for (let i = 0; i < from.length; i++) {
+    if (from[i] !== to[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isSamePath(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -398,6 +398,16 @@ function applyPatchOpSequential(
       return movePaths;
     }
 
+    const fromResolved = resolveValueAtPointerInDoc(
+      baseDoc,
+      op.from,
+      opIndex,
+      session.pointerCache,
+    );
+    if (!fromResolved.ok) {
+      return fromResolved;
+    }
+
     if (isStrictDescendantPath(movePaths.fromPath, movePaths.toPath)) {
       return {
         ok: false,
@@ -407,16 +417,6 @@ function applyPatchOpSequential(
         path: op.path,
         opIndex,
       };
-    }
-
-    const fromResolved = resolveValueAtPointerInDoc(
-      baseDoc,
-      op.from,
-      opIndex,
-      session.pointerCache,
-    );
-    if (!fromResolved.ok) {
-      return fromResolved;
     }
 
     if (isSamePath(movePaths.fromPath, movePaths.toPath)) {

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -804,6 +804,22 @@ describe("clock and state", () => {
     expect(toJson(state)).toEqual({ a: { b: 1 } });
   });
 
+  it("preserves missing-source errors for sequential descendant-shaped moves", () => {
+    const state = createState({ a: 1 }, { actor: "A" });
+    const before = serializeState(state);
+    const result = tryApplyPatch(state, [{ op: "move", from: "/missing", path: "/missing/c" }], {
+      semantics: "sequential",
+    });
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("MISSING_PARENT");
+      expect(result.error.path).toBe("/missing");
+      expect(result.error.opIndex).toBe(0);
+    }
+    expect(serializeState(state)).toEqual(before);
+  });
+
   it("treats sequential self-move as a true no-op after validating the source", () => {
     const state = createState({ a: { b: 1 } }, { actor: "A" });
     const before = serializeState(state);

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -787,6 +787,50 @@ describe("clock and state", () => {
     expect(toJson(next)).toEqual(["c", "a", "b"]);
   });
 
+  it("rejects sequential descendant moves before mutating", () => {
+    const state = createState({ a: { b: 1 } }, { actor: "A" });
+    const before = serializeState(state);
+    const result = tryApplyPatch(state, [{ op: "move", from: "/a", path: "/a/b/c" }], {
+      semantics: "sequential",
+    });
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("INVALID_MOVE");
+      expect(result.error.path).toBe("/a/b/c");
+      expect(result.error.opIndex).toBe(0);
+    }
+    expect(serializeState(state)).toEqual(before);
+    expect(toJson(state)).toEqual({ a: { b: 1 } });
+  });
+
+  it("treats sequential self-move as a true no-op after validating the source", () => {
+    const state = createState({ a: { b: 1 } }, { actor: "A" });
+    const before = serializeState(state);
+    const next = applyPatch(state, [{ op: "move", from: "/a", path: "/a" }], {
+      semantics: "sequential",
+    });
+
+    expect(serializeState(next)).toEqual(before);
+    expect(next.clock.ctr).toBe(state.clock.ctr);
+    expect(observedVersionVector(next)).toEqual(observedVersionVector(state));
+    expect(toJson(next)).toEqual({ a: { b: 1 } });
+  });
+
+  it("rejects sequential self-move when the source is missing", () => {
+    const state = createState({ a: 1 }, { actor: "A" });
+    const result = tryApplyPatch(state, [{ op: "move", from: "/missing", path: "/missing" }], {
+      semantics: "sequential",
+    });
+
+    expect(result.ok).toBeFalse();
+    if (!result.ok) {
+      expect(result.error.reason).toBe("MISSING_PARENT");
+      expect(result.error.path).toBe("/missing");
+      expect(result.error.opIndex).toBe(0);
+    }
+  });
+
   it("supports mixing sequential semantics with an explicit base state", () => {
     const base = createState({ list: [1, 2] }, { actor: "A" });
     const head = applyPatch(base, [{ op: "add", path: "/list/1", value: 9 }], {


### PR DESCRIPTION
## Summary

Fixes #164.

This updates the high-level sequential `applyPatch` path so RFC 6902 `move` operations validate source and target relationships before applying any remove/add logic. Descendant moves are now rejected with `INVALID_MOVE`, matching the lower-level compiler behavior, instead of first removing the source and later surfacing `MISSING_PARENT`.

Self-moves now validate that the source exists, then return as a true no-op without advancing the CRDT clock or rewriting document metadata.

## Root Cause

The sequential move path resolved the source value and immediately applied the remove step. For invalid descendant targets like moving `/a` to `/a/b/c`, that deleted `/a` before the add target was checked, so the operation failed later as a missing parent and left non-atomic paths vulnerable to partial mutation. Self-moves followed the same remove/add flow, which recreated metadata and advanced clocks despite being a JSON no-op.

## Changes

- Parse and compare move `from`/`path` pointers before mutation in the sequential apply path.
- Reject strict descendant move targets with structured `INVALID_MOVE` errors.
- Treat validated self-moves as no-ops that preserve clocks and serialized state metadata.
- Add regression tests for descendant move rejection, self-move metadata preservation, and missing-source self-move validation.
- Add a patch changeset for the bug fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun run test`