### PR TITLE
fix: reject shadowed serialized object entries

### DIFF
--- a/.changeset/quiet-hornets-validate.md
+++ b/.changeset/quiet-hornets-validate.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Reject serialized object entries shadowed by equal-or-newer tombstones during validation and deserialization.

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -371,7 +371,7 @@ function deserializeNode(
       const entryPath = `${path}/entries/${k}`;
       const entryRaw = asRecord(v, entryPath);
       const dot = readDot(entryRaw.dot, `${entryPath}/dot`);
-      assertObjectEntryNotShadowedByTombstone(dot, tombstoneRaw, k, entryPath);
+      assertObjectEntryNotShadowedByTombstone(dot, tombstoneRaw, k, entryPath, path);
       if (observed) {
         observeVersionVectorDot(observed, dot);
       }
@@ -539,7 +539,7 @@ function validateSerializedNode(
       const entryPath = `${path}/entries/${k}`;
       const entryRaw = asRecord(v, entryPath);
       const dot = readDot(entryRaw.dot, `${entryPath}/dot`);
-      assertObjectEntryNotShadowedByTombstone(dot, tombstoneRaw, k, entryPath);
+      assertObjectEntryNotShadowedByTombstone(dot, tombstoneRaw, k, entryPath, path);
       validateSerializedNode(entryRaw.node, `${entryPath}/node`, depth + 1, budgetMeter, signal);
     }
 
@@ -628,12 +628,13 @@ function assertObjectEntryNotShadowedByTombstone(
   tombstoneRaw: Record<string, unknown>,
   key: string,
   entryPath: string,
+  objectPath: string,
 ): void {
   if (!Object.hasOwn(tombstoneRaw, key)) {
     return;
   }
 
-  const tombstonePath = entryPath.replace("/entries/", "/tombstone/");
+  const tombstonePath = `${objectPath}/tombstone/${key}`;
   const tombstoneValue = tombstoneRaw[key];
   const tombstoneDot = readDot(tombstoneValue, tombstonePath);
   if (compareDot(tombstoneDot, entryDot) >= 0) {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -32,7 +32,7 @@ import {
 } from "./cancellation";
 import { createClock } from "./clock";
 import { TraversalDepthError, assertTraversalDepth } from "./depth";
-import { dotToElemId } from "./dot";
+import { compareDot, dotToElemId } from "./dot";
 import {
   observeVersionVectorDot,
   readCachedObservedVersionVector,
@@ -371,6 +371,7 @@ function deserializeNode(
       const entryPath = `${path}/entries/${k}`;
       const entryRaw = asRecord(v, entryPath);
       const dot = readDot(entryRaw.dot, `${entryPath}/dot`);
+      assertObjectEntryNotShadowedByTombstone(dot, tombstoneRaw, k, entryPath);
       if (observed) {
         observeVersionVectorDot(observed, dot);
       }
@@ -537,7 +538,8 @@ function validateSerializedNode(
       throwIfAborted(signal);
       const entryPath = `${path}/entries/${k}`;
       const entryRaw = asRecord(v, entryPath);
-      readDot(entryRaw.dot, `${entryPath}/dot`);
+      const dot = readDot(entryRaw.dot, `${entryPath}/dot`);
+      assertObjectEntryNotShadowedByTombstone(dot, tombstoneRaw, k, entryPath);
       validateSerializedNode(entryRaw.node, `${entryPath}/node`, depth + 1, budgetMeter, signal);
     }
 
@@ -619,6 +621,28 @@ function validateSerializedNode(
   }
 
   assertAcyclicSerializedRgaPredecessors(predecessors, path);
+}
+
+function assertObjectEntryNotShadowedByTombstone(
+  entryDot: Dot,
+  tombstoneRaw: Record<string, unknown>,
+  key: string,
+  entryPath: string,
+): void {
+  if (!Object.hasOwn(tombstoneRaw, key)) {
+    return;
+  }
+
+  const tombstonePath = entryPath.replace("/entries/", "/tombstone/");
+  const tombstoneValue = tombstoneRaw[key];
+  const tombstoneDot = readDot(tombstoneValue, tombstonePath);
+  if (compareDot(tombstoneDot, entryDot) >= 0) {
+    fail(
+      "INVALID_SERIALIZED_INVARIANT",
+      `${entryPath}/dot`,
+      "object entry dot must be newer than its tombstone dot",
+    );
+  }
 }
 
 function assertAcyclicRgaPredecessors(elems: Map<string, RgaElem>, path: string): void {

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -1921,6 +1921,110 @@ describe("serialization", () => {
     expect(next.clock.ctr).toBe(5);
   });
 
+  it("rejects object entries shadowed by newer tombstones during deserialization", () => {
+    const malformed = {
+      version: 1,
+      root: {
+        kind: "obj",
+        entries: {
+          x: {
+            node: { kind: "lww", value: 1, dot: { actor: "A", ctr: 1 } },
+            dot: { actor: "A", ctr: 1 },
+          },
+        },
+        tombstone: { x: { actor: "A", ctr: 2 } },
+      },
+    } as unknown as SerializedDoc;
+
+    try {
+      deserializeDoc(malformed);
+    } catch (error) {
+      expect(error).toBeInstanceOf(DeserializeError);
+      if (error instanceof DeserializeError) {
+        expect(error.reason).toBe("INVALID_SERIALIZED_INVARIANT");
+        expect(error.path).toBe("/root/entries/x/dot");
+      }
+      return;
+    }
+
+    throw new Error("Expected deserializeDoc to reject shadowed object entries");
+  });
+
+  it("rejects object entries shadowed by equal tombstones during deserialization", () => {
+    const malformed = {
+      version: 1,
+      root: {
+        kind: "obj",
+        entries: {
+          x: {
+            node: { kind: "lww", value: 1, dot: { actor: "A", ctr: 1 } },
+            dot: { actor: "A", ctr: 1 },
+          },
+        },
+        tombstone: { x: { actor: "A", ctr: 1 } },
+      },
+    } as unknown as SerializedDoc;
+
+    const result = tryDeserializeDoc(malformed);
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected tryDeserializeDoc to fail");
+    }
+
+    expect(result.error).toBeInstanceOf(DeserializeError);
+    if (result.error instanceof DeserializeError) {
+      expect(result.error.reason).toBe("INVALID_SERIALIZED_INVARIANT");
+      expect(result.error.path).toBe("/root/entries/x/dot");
+    }
+  });
+
+  it("validates object tombstone conflicts without exposing shadowed entries", () => {
+    const malformed = {
+      version: 1,
+      root: {
+        kind: "obj",
+        entries: {
+          x: {
+            node: { kind: "lww", value: 1, dot: { actor: "A", ctr: 1 } },
+            dot: { actor: "A", ctr: 1 },
+          },
+        },
+        tombstone: { x: { actor: "A", ctr: 2 } },
+      },
+    } as unknown as SerializedDoc;
+
+    const result = validateSerializedDoc(malformed);
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected validateSerializedDoc to fail");
+    }
+
+    expect(result.error).toBeInstanceOf(DeserializeError);
+    if (result.error instanceof DeserializeError) {
+      expect(result.error.reason).toBe("INVALID_SERIALIZED_INVARIANT");
+      expect(result.error.path).toBe("/root/entries/x/dot");
+    }
+  });
+
+  it("accepts object entries that resurrect older tombstones", () => {
+    const payload = {
+      version: 1,
+      root: {
+        kind: "obj",
+        entries: {
+          x: {
+            node: { kind: "lww", value: 1, dot: { actor: "A", ctr: 2 } },
+            dot: { actor: "A", ctr: 2 },
+          },
+        },
+        tombstone: { x: { actor: "A", ctr: 1 } },
+      },
+    } as unknown as SerializedDoc;
+
+    expect(validateSerializedDoc(payload)).toEqual({ ok: true });
+    expect(materialize(deserializeDoc(payload).root)).toEqual({ x: 1 });
+  });
+
   it("rejects sequence elements whose key does not match element id", () => {
     const malformed = {
       root: {

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -2006,6 +2006,43 @@ describe("serialization", () => {
     }
   });
 
+  it("reports nested object tombstone conflict shape errors at the tombstone path", () => {
+    const malformed = {
+      version: 1,
+      root: {
+        kind: "obj",
+        entries: {
+          outer: {
+            node: {
+              kind: "obj",
+              entries: {
+                inner: {
+                  node: { kind: "lww", value: 1, dot: { actor: "A", ctr: 2 } },
+                  dot: { actor: "A", ctr: 2 },
+                },
+              },
+              tombstone: { inner: { actor: 42, ctr: 3 } },
+            },
+            dot: { actor: "A", ctr: 1 },
+          },
+        },
+        tombstone: {},
+      },
+    } as unknown as SerializedDoc;
+
+    const result = validateSerializedDoc(malformed);
+    expect(result.ok).toBeFalse();
+    if (result.ok) {
+      throw new Error("Expected validateSerializedDoc to fail");
+    }
+
+    expect(result.error).toBeInstanceOf(DeserializeError);
+    if (result.error instanceof DeserializeError) {
+      expect(result.error.reason).toBe("INVALID_SERIALIZED_SHAPE");
+      expect(result.error.path).toBe("/root/entries/outer/node/tombstone/inner/actor");
+    }
+  });
+
   it("accepts object entries that resurrect older tombstones", () => {
     const payload = {
       version: 1,


### PR DESCRIPTION
## Summary

Fixes #165.

This PR makes serialized object validation and deserialization enforce delete-wins semantics when an object contains both a live `entries[key]` value and a `tombstone[key]` dot for the same key.

## Changes

- Reject object entries whose dot is equal to or older than the matching tombstone dot during `deserializeDoc`.
- Apply the same invariant in `validateSerializedDoc`, so non-runtime validation catches the malformed shape too.
- Preserve valid resurrection payloads where the entry dot is newer than the tombstone dot.
- Use own-property tombstone lookup so unsafe keys like `__proto__` are still handled as data without inherited-property confusion.
- Add a patch changeset.

## Testing

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`