### PR TITLE
fix: reject non-plain serialized JSON values

### DIFF
--- a/.changeset/modern-buckets-sip.md
+++ b/.changeset/modern-buckets-sip.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Reject non-plain object instances inside serialized LWW JSON values during validation and deserialization.

--- a/src/json-value.ts
+++ b/src/json-value.ts
@@ -192,12 +192,8 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
     return false;
   }
 
-  if (Object.prototype.toString.call(value) !== "[object Object]") {
-    return false;
-  }
-
   const prototype = Object.getPrototypeOf(value);
-  return prototype === null || Object.getPrototypeOf(prototype) === null;
+  return prototype === null || prototype === Object.prototype;
 }
 
 function isNonFiniteNumber(value: unknown): value is number {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -852,7 +852,7 @@ function assertJsonValue(
     return;
   }
 
-  if (!isRecord(value)) {
+  if (!isPlainJsonObject(value)) {
     fail("INVALID_SERIALIZED_SHAPE", path, "expected JSON value");
   }
 
@@ -887,4 +887,17 @@ function toDeserializeFailure(error: unknown): DeserializeFailure | null {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (Object.prototype.toString.call(value) !== "[object Object]") {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === null || Object.getPrototypeOf(prototype) === null;
 }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -894,10 +894,6 @@ function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
     return false;
   }
 
-  if (Object.prototype.toString.call(value) !== "[object Object]") {
-    return false;
-  }
-
   const prototype = Object.getPrototypeOf(value);
-  return prototype === null || Object.getPrototypeOf(prototype) === null;
+  return prototype === null || prototype === Object.prototype;
 }

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -1882,6 +1882,100 @@ describe("serialization", () => {
     expect(toJson(deserializeState(legacyState).doc)).toEqual({ counter: 1 });
   });
 
+  it("rejects non-plain serialized LWW JSON objects with typed failures", () => {
+    const invalidPayloads = nonPlainObjectCases().flatMap((sample) => [
+      {
+        label: `${sample.label} root`,
+        value: sample.create(),
+        path: "/root/value",
+      },
+      {
+        label: `${sample.label} nested`,
+        value: { nested: sample.create() },
+        path: "/root/value/nested",
+      },
+    ]);
+
+    for (const sample of invalidPayloads) {
+      const payload = {
+        version: 1,
+        root: {
+          kind: "lww",
+          value: sample.value,
+          dot: { actor: "A", ctr: 1 },
+        },
+      } as unknown as SerializedDoc;
+      const docResult = tryDeserializeDoc(payload);
+      const validationResult = validateSerializedDoc(payload);
+      const statePayload = {
+        version: 1,
+        doc: payload,
+        clock: { actor: "A", ctr: 1 },
+      };
+      const stateResult = tryDeserializeState(statePayload);
+      const stateValidationResult = validateSerializedState(statePayload);
+
+      expect(docResult.ok, sample.label).toBeFalse();
+      expect(validationResult.ok, sample.label).toBeFalse();
+      expect(stateResult.ok, sample.label).toBeFalse();
+      expect(stateValidationResult.ok, sample.label).toBeFalse();
+
+      if (docResult.ok || validationResult.ok || stateResult.ok || stateValidationResult.ok) {
+        throw new Error(`Expected typed deserialize failure for ${sample.label}`);
+      }
+
+      expect(docResult.error).toBeInstanceOf(DeserializeError);
+      expect(validationResult.error).toBeInstanceOf(DeserializeError);
+      expect(stateResult.error).toBeInstanceOf(DeserializeError);
+      expect(stateValidationResult.error).toBeInstanceOf(DeserializeError);
+      if (
+        !(docResult.error instanceof DeserializeError) ||
+        !(validationResult.error instanceof DeserializeError) ||
+        !(stateResult.error instanceof DeserializeError) ||
+        !(stateValidationResult.error instanceof DeserializeError)
+      ) {
+        throw new Error(`Expected DeserializeError for ${sample.label}`);
+      }
+
+      expect(docResult.error.reason).toBe("INVALID_SERIALIZED_SHAPE");
+      expect(validationResult.error.reason).toBe("INVALID_SERIALIZED_SHAPE");
+      expect(stateResult.error.reason).toBe("INVALID_SERIALIZED_SHAPE");
+      expect(stateValidationResult.error.reason).toBe("INVALID_SERIALIZED_SHAPE");
+      expect(docResult.error.path).toBe(sample.path);
+      expect(validationResult.error.path).toBe(sample.path);
+      expect(stateResult.error.path).toBe(sample.path);
+      expect(stateValidationResult.error.path).toBe(sample.path);
+    }
+  });
+
+  it("accepts plain and null-prototype objects in serialized LWW JSON values", () => {
+    const nullPrototypeObject = Object.create(null) as Record<string, JsonValue>;
+    nullPrototypeObject.keep = "value";
+    const payloads: readonly SerializedDoc[] = [
+      {
+        version: 1,
+        root: {
+          kind: "lww",
+          value: { plain: { nested: true } },
+          dot: { actor: "A", ctr: 1 },
+        },
+      },
+      {
+        version: 1,
+        root: {
+          kind: "lww",
+          value: nullPrototypeObject,
+          dot: { actor: "A", ctr: 1 },
+        },
+      },
+    ];
+
+    for (const payload of payloads) {
+      expect(tryDeserializeDoc(payload).ok).toBeTrue();
+      expect(validateSerializedDoc(payload).ok).toBeTrue();
+    }
+  });
+
   it("repairs stale serialized clock counters during state deserialization", () => {
     const base = createState({ a: 1 }, { actor: "A" });
     const state = applyPatch(base, [{ op: "add", path: "/b", value: 2 }]);

--- a/tests/state-core.test.ts
+++ b/tests/state-core.test.ts
@@ -349,6 +349,27 @@ describe("clock and state", () => {
     }
   });
 
+  it("uses exact prototype identity for strict runtime JSON object validation", () => {
+    const taggedPlainObject = Object.assign({ keep: true }, { [Symbol.toStringTag]: "Custom" });
+    const intermediatePrototype = Object.create(null) as Record<string, unknown>;
+    const exoticObject = Object.create(intermediatePrototype) as Record<string, JsonValue>;
+    exoticObject.value = true;
+
+    expect(() =>
+      createState(taggedPlainObject as unknown as JsonValue, {
+        actor: "A",
+        jsonValidation: "strict",
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      createState(exoticObject as unknown as JsonValue, {
+        actor: "A",
+        jsonValidation: "strict",
+      }),
+    ).toThrow(JsonValueValidationError);
+  });
+
   it("normalizes non-plain object initial values consistently in normalize jsonValidation mode", () => {
     const invalidEntries = Object.fromEntries(
       nonPlainObjectCases().map((sample) => [sample.label, sample.create()]),
@@ -1951,6 +1972,10 @@ describe("serialization", () => {
   it("accepts plain and null-prototype objects in serialized LWW JSON values", () => {
     const nullPrototypeObject = Object.create(null) as Record<string, JsonValue>;
     nullPrototypeObject.keep = "value";
+    const taggedPlainObject = Object.assign(
+      { keep: true },
+      { [Symbol.toStringTag]: "SerializedPlainObject" },
+    );
     const payloads: readonly SerializedDoc[] = [
       {
         version: 1,
@@ -1968,12 +1993,45 @@ describe("serialization", () => {
           dot: { actor: "A", ctr: 1 },
         },
       },
+      {
+        version: 1,
+        root: {
+          kind: "lww",
+          value: taggedPlainObject as unknown as JsonValue,
+          dot: { actor: "A", ctr: 1 },
+        },
+      },
     ];
 
     for (const payload of payloads) {
       expect(tryDeserializeDoc(payload).ok).toBeTrue();
       expect(validateSerializedDoc(payload).ok).toBeTrue();
     }
+  });
+
+  it("rejects serialized LWW JSON values with exotic null-prototype ancestors", () => {
+    const intermediatePrototype = Object.create(null) as Record<string, unknown>;
+    const exoticObject = Object.create(intermediatePrototype) as Record<string, JsonValue>;
+    exoticObject.value = true;
+    const payload = {
+      version: 1,
+      root: {
+        kind: "lww",
+        value: exoticObject,
+        dot: { actor: "A", ctr: 1 },
+      },
+    } as unknown as SerializedDoc;
+    const result = tryDeserializeDoc(payload);
+    const validationResult = validateSerializedDoc(payload);
+
+    expect(result.ok).toBeFalse();
+    expect(validationResult.ok).toBeFalse();
+    if (result.ok || validationResult.ok) {
+      throw new Error("Expected serialized exotic object validation to fail");
+    }
+
+    expect(result.error).toBeInstanceOf(DeserializeError);
+    expect(validationResult.error).toBeInstanceOf(DeserializeError);
   });
 
   it("repairs stale serialized clock counters during state deserialization", () => {


### PR DESCRIPTION
## Summary

Fixes #166.

Serialized LWW JSON value validation now rejects non-plain object instances instead of treating every non-array object as JSON-compatible data. This applies to both throwing and non-throwing deserialize/validate paths because the shared serialized JSON validator now requires object values to be plain objects or null-prototype objects.

## Changes

- Reject `Date`, `Map`, `Set`, typed arrays, class instances, and other non-plain objects inside serialized LWW JSON values.
- Preserve support for ordinary plain objects and null-prototype objects in serialized JSON payloads.
- Add regression coverage for direct and nested invalid serialized LWW values across `tryDeserializeDoc`, `validateSerializedDoc`, `tryDeserializeState`, and `validateSerializedState`.
- Add a patch changeset for the validation fix.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun test tests/state-core.test.ts`
- `bun test`
- `bun typecheck`