### PR TITLE
fix: honor crdt diff cancellation

### DIFF
--- a/.changeset/calm-dragons-cancel.md
+++ b/.changeset/calm-dragons-cancel.md
@@ -1,0 +1,5 @@
+---
+"json-patch-to-crdt": patch
+---
+
+Honor AbortSignal cancellation in the CRDT-native crdtToJsonPatch traversal path.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -17,6 +17,7 @@ import type {
 } from "./types";
 
 import { createBudgetMeter } from "./budget";
+import { throwIfAborted } from "./cancellation";
 import { TraversalDepthError, assertTraversalDepth, toDepthApplyError } from "./depth";
 import { compareDot, dotToElemId } from "./dot";
 import { materialize } from "./materialize";
@@ -1226,8 +1227,14 @@ function rebaseSequenceWindowDiffOps(
   return true;
 }
 
-function nodesJsonEqual(baseNode: Node, headNode: Node, depth: number): boolean {
+function nodesJsonEqual(
+  baseNode: Node,
+  headNode: Node,
+  options: DiffOptions,
+  depth: number,
+): boolean {
   assertTraversalDepth(depth);
+  throwIfAborted(options.signal);
 
   if (baseNode === headNode) {
     return true;
@@ -1250,12 +1257,13 @@ function nodesJsonEqual(baseNode: Node, headNode: Node, depth: number): boolean 
     }
 
     for (const [key, baseEntry] of baseNode.entries.entries()) {
+      throwIfAborted(options.signal);
       const headEntry = headObj.entries.get(key);
       if (!headEntry) {
         return false;
       }
 
-      if (!nodesJsonEqual(baseEntry.node, headEntry.node, depth + 1)) {
+      if (!nodesJsonEqual(baseEntry.node, headEntry.node, options, depth + 1)) {
         return false;
       }
     }
@@ -1270,13 +1278,14 @@ function nodesJsonEqual(baseNode: Node, headNode: Node, depth: number): boolean 
   const headCursor = rgaCreateLinearCursor(headSeq);
 
   while (true) {
+    throwIfAborted(options.signal);
     const baseElem = baseCursor.next();
     const headElem = headCursor.next();
     if (baseElem === undefined || headElem === undefined) {
       return baseElem === undefined && headElem === undefined;
     }
 
-    if (!nodesJsonEqual(baseElem.value, headElem.value, depth + 1)) {
+    if (!nodesJsonEqual(baseElem.value, headElem.value, options, depth + 1)) {
       return false;
     }
   }
@@ -1291,6 +1300,7 @@ function diffObjectNodes(
   depth: number,
 ): void {
   assertTraversalDepth(depth);
+  throwIfAborted(options.signal);
 
   const baseKeys = [...baseNode.entries.keys()].sort();
   const headKeys = [...headNode.entries.keys()].sort();
@@ -1299,6 +1309,7 @@ function diffObjectNodes(
   let headIndex = 0;
 
   while (baseIndex < baseKeys.length && headIndex < headKeys.length) {
+    throwIfAborted(options.signal);
     const baseKey = baseKeys[baseIndex]!;
     const headKey = headKeys[headIndex]!;
 
@@ -1320,6 +1331,7 @@ function diffObjectNodes(
   }
 
   while (baseIndex < baseKeys.length) {
+    throwIfAborted(options.signal);
     const baseKey = baseKeys[baseIndex]!;
     path.push(baseKey);
     ops.push({ op: "remove", path: stringifyJsonPointer(path) });
@@ -1330,6 +1342,7 @@ function diffObjectNodes(
   baseIndex = 0;
   headIndex = 0;
   while (baseIndex < baseKeys.length && headIndex < headKeys.length) {
+    throwIfAborted(options.signal);
     const baseKey = baseKeys[baseIndex]!;
     const headKey = headKeys[headIndex]!;
 
@@ -1356,6 +1369,7 @@ function diffObjectNodes(
   }
 
   while (headIndex < headKeys.length) {
+    throwIfAborted(options.signal);
     const headKey = headKeys[headIndex]!;
     const headEntry = headNode.entries.get(headKey)!;
     path.push(headKey);
@@ -1371,13 +1385,14 @@ function diffObjectNodes(
   baseIndex = 0;
   headIndex = 0;
   while (baseIndex < baseKeys.length && headIndex < headKeys.length) {
+    throwIfAborted(options.signal);
     const baseKey = baseKeys[baseIndex]!;
     const headKey = headKeys[headIndex]!;
 
     if (baseKey === headKey) {
       const baseEntry = baseNode.entries.get(baseKey)!;
       const headEntry = headNode.entries.get(headKey)!;
-      if (!nodesJsonEqual(baseEntry.node, headEntry.node, depth + 1)) {
+      if (!nodesJsonEqual(baseEntry.node, headEntry.node, options, depth + 1)) {
         path.push(baseKey);
         diffNodeToPatch(path, baseEntry.node, headEntry.node, options, ops, depth + 1);
         path.pop();
@@ -1404,6 +1419,7 @@ function diffSequenceNodes(
   ops: JsonPatchOp[],
   depth: number,
 ): void {
+  throwIfAborted(options.signal);
   const arrayStrategy = options.arrayStrategy ?? "lcs";
   if (arrayStrategy === "atomic") {
     const seqOps = diffJsonPatch(materialize(baseNode), materialize(headSeq), options);
@@ -1418,8 +1434,14 @@ function diffSequenceNodes(
   let prefixLength = 0;
   while (
     prefixLength < sharedLength &&
-    nodesJsonEqual(baseElems[prefixLength]!.value, headElems[prefixLength]!.value, depth + 1)
+    nodesJsonEqual(
+      baseElems[prefixLength]!.value,
+      headElems[prefixLength]!.value,
+      options,
+      depth + 1,
+    )
   ) {
+    throwIfAborted(options.signal);
     prefixLength += 1;
   }
 
@@ -1432,8 +1454,9 @@ function diffSequenceNodes(
   while (
     baseEnd > prefixLength &&
     headEnd > prefixLength &&
-    nodesJsonEqual(baseElems[baseEnd - 1]!.value, headElems[headEnd - 1]!.value, depth + 1)
+    nodesJsonEqual(baseElems[baseEnd - 1]!.value, headElems[headEnd - 1]!.value, options, depth + 1)
   ) {
+    throwIfAborted(options.signal);
     baseEnd -= 1;
     headEnd -= 1;
   }
@@ -1474,6 +1497,7 @@ function diffNodeToPatch(
   depth: number,
 ): void {
   assertTraversalDepth(depth);
+  throwIfAborted(options.signal);
 
   if (baseNode === headNode) {
     return;
@@ -1521,6 +1545,7 @@ function diffNodeToPatch(
  * @returns An array of JSON Patch operations that transform base into head.
  */
 export function crdtToJsonPatch(base: Doc, head: Doc, options?: DiffOptions): JsonPatchOp[] {
+  throwIfAborted(options?.signal);
   // Preserve full-document runtime guardrail behavior for strict/normalize modes.
   if ((options?.jsonValidation ?? "none") !== "none" || options?.resourceBudget !== undefined) {
     return diffJsonPatch(materialize(base.root), materialize(head.root), options);
@@ -1536,6 +1561,7 @@ export function crdtNodesToJsonPatch(
   options?: DiffOptions,
   depth = 0,
 ): JsonPatchOp[] {
+  throwIfAborted(options?.signal);
   const ops: JsonPatchOp[] = [];
   diffNodeToPatch([], baseNode, headNode, options ?? {}, ops, depth);
   return ops;

--- a/tests/cancellation.test.ts
+++ b/tests/cancellation.test.ts
@@ -73,28 +73,24 @@ describe("operation cancellation", () => {
 
   it("cancels CRDT-native sequence traversal", () => {
     const base = createState(
-      { items: Array.from({ length: 100 }, (_, index) => index) },
-      {
-        actor: "A",
-      },
+      Array.from({ length: 100 }, (_, index) => index),
+      { actor: "A" },
     );
     const head = createState(
-      { items: Array.from({ length: 100 }, (_, index) => index) },
-      {
-        actor: "B",
-      },
+      Array.from({ length: 100 }, (_, index) => index),
+      { actor: "B" },
     );
-    expect(head.doc.root.kind).toBe("obj");
-    if (head.doc.root.kind !== "obj") {
-      throw new Error("expected object root");
+    expect(head.doc.root.kind).toBe("seq");
+    if (head.doc.root.kind !== "seq") {
+      throw new Error("expected sequence root");
     }
 
-    const items = head.doc.root.entries.get("items")!.node as RgaSeq;
+    const items = head.doc.root as RgaSeq;
     Array.from(items.elems.values()).at(-1)!.value = newReg(-1, { actor: "C", ctr: 1 });
 
     expect(() =>
       crdtToJsonPatch(base.doc, head.doc, {
-        signal: abortOnCheck(5, "stop"),
+        signal: abortOnCheck(6, "stop"),
       }),
     ).toThrow(OperationCancelledError);
   });

--- a/tests/cancellation.test.ts
+++ b/tests/cancellation.test.ts
@@ -15,6 +15,7 @@ import {
   toJson,
   type JsonValue,
 } from "../src/index";
+import { crdtToJsonPatch, newReg, type RgaSeq } from "../src/internals";
 
 function abortedSignal(reason = "deadline exceeded"): AbortSignal {
   return AbortSignal.abort(reason);
@@ -44,6 +45,56 @@ describe("operation cancellation", () => {
     expect(() =>
       diffJsonPatch(makeLargeObject(100), makeLargeObject(100), {
         signal: abortedSignal(),
+      }),
+    ).toThrow(OperationCancelledError);
+  });
+
+  it("cancels CRDT-native diff work before traversal", () => {
+    const base = createState({ x: 1 }, { actor: "A" });
+    const head = createState({ x: 2 }, { actor: "B" });
+
+    expect(() =>
+      crdtToJsonPatch(base.doc, head.doc, {
+        signal: abortedSignal("stop"),
+      }),
+    ).toThrow(OperationCancelledError);
+  });
+
+  it("cancels CRDT-native object traversal", () => {
+    const base = createState(makeLargeObject(100), { actor: "A" });
+    const head = createState({ ...makeLargeObject(100), key99: -1 }, { actor: "B" });
+
+    expect(() =>
+      crdtToJsonPatch(base.doc, head.doc, {
+        signal: abortOnCheck(5, "stop"),
+      }),
+    ).toThrow(OperationCancelledError);
+  });
+
+  it("cancels CRDT-native sequence traversal", () => {
+    const base = createState(
+      { items: Array.from({ length: 100 }, (_, index) => index) },
+      {
+        actor: "A",
+      },
+    );
+    const head = createState(
+      { items: Array.from({ length: 100 }, (_, index) => index) },
+      {
+        actor: "B",
+      },
+    );
+    expect(head.doc.root.kind).toBe("obj");
+    if (head.doc.root.kind !== "obj") {
+      throw new Error("expected object root");
+    }
+
+    const items = head.doc.root.entries.get("items")!.node as RgaSeq;
+    Array.from(items.elems.values()).at(-1)!.value = newReg(-1, { actor: "C", ctr: 1 });
+
+    expect(() =>
+      crdtToJsonPatch(base.doc, head.doc, {
+        signal: abortOnCheck(5, "stop"),
       }),
     ).toThrow(OperationCancelledError);
   });


### PR DESCRIPTION
## Summary

- Honor `DiffOptions.signal` before entering the CRDT-native `crdtToJsonPatch` traversal path.
- Check cancellation during native object traversal, sequence traversal, recursive node equality checks, and node diff dispatch.
- Preserve cancellation propagation for nested `diffJsonPatch` calls by continuing to pass the original options object.
- Add a patch changeset for the cancellation fix.

## Tests

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #167